### PR TITLE
Supabase DB migrations + documentation

### DIFF
--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -1,0 +1,248 @@
+# Database Schema
+
+This document describes the Supabase (PostgreSQL) database schema for Uncooked.
+
+## Entity Relationship Diagram
+
+```
+┌─────────────────┐
+│   auth.users    │  (Supabase Auth - managed)
+│─────────────────│
+│ id (PK)         │
+│ email           │
+│ ...             │
+└────────┬────────┘
+         │
+         │ 1:1
+         ▼
+┌─────────────────┐       ┌─────────────────┐
+│     users       │       │     resumes     │
+│─────────────────│       │─────────────────│
+│ id (PK, FK)     │◄──────│ user_id (FK)    │
+│ full_name       │  1:N  │ id (PK)         │
+│ avatar_url      │       │ title           │
+│ created_at      │       │ content         │
+│ updated_at      │       │ file_url        │
+└────────┬────────┘       │ is_primary      │
+         │                └────────┬────────┘
+         │ 1:N                     │
+         ▼                         │
+┌─────────────────┐                │
+│ company_profiles│                │
+│─────────────────│                │
+│ id (PK)         │                │
+│ user_id (FK)    │                │
+│ company_name    │                │
+│ company_website │                │
+│ industry        │                │
+│ notes           │                │
+└────────┬────────┘                │
+         │                         │
+    ┌────┴────┐                    │
+    │         │                    │
+    │ 1:N     │ 1:N                │
+    ▼         ▼                    │
+┌─────────────────┐      ┌─────────────────┐
+│research_sessions│      │ job_applications│
+│─────────────────│      │─────────────────│
+│ id (PK)         │      │ id (PK)         │
+│ user_id (FK)    │      │ user_id (FK)    │
+│ company_profile │      │ company_profile │
+│   _id (FK)      │      │   _id (FK)      │
+│ title           │      │ resume_id (FK)──┼──┘
+│ messages (JSONB)│      │ job_title       │
+└─────────────────┘      │ status (ENUM)   │
+                         │ applied_at      │
+                         └─────────────────┘
+```
+
+---
+
+## Tables
+
+### `users`
+
+Extends Supabase Auth with additional profile fields. Auto-created on signup via trigger.
+
+| Column       | Type        | Constraints             | Description              |
+| ------------ | ----------- | ----------------------- | ------------------------ |
+| `id`         | UUID        | PK, FK → auth.users     | User's auth ID           |
+| `email`      | TEXT        |                         | User's email address     |
+| `full_name`  | TEXT        |                         | User's display name      |
+| `avatar_url` | TEXT        |                         | Profile picture URL      |
+| `created_at` | TIMESTAMPTZ | NOT NULL, DEFAULT now() | When profile was created |
+| `updated_at` | TIMESTAMPTZ | NOT NULL, DEFAULT now() | Last update timestamp    |
+
+**RLS Policies:**
+
+- Users can SELECT, INSERT, UPDATE their own row only
+
+---
+
+### `company_profiles`
+
+Saved companies in user's Research Board.
+
+| Column            | Type        | Constraints                   | Description                     |
+| ----------------- | ----------- | ----------------------------- | ------------------------------- |
+| `id`              | UUID        | PK, DEFAULT gen_random_uuid() | Unique identifier               |
+| `user_id`         | UUID        | NOT NULL, FK → users          | Owner of the profile            |
+| `company_name`    | TEXT        | NOT NULL                      | Company name                    |
+| `company_website` | TEXT        |                               | Company website URL             |
+| `industry`        | TEXT        |                               | Industry sector                 |
+| `company_size`    | TEXT        |                               | Size (startup, mid, enterprise) |
+| `location`        | TEXT        |                               | HQ or office location           |
+| `notes`           | TEXT        |                               | User's notes about company      |
+| `created_at`      | TIMESTAMPTZ | NOT NULL, DEFAULT now()       | Created timestamp               |
+| `updated_at`      | TIMESTAMPTZ | NOT NULL, DEFAULT now()       | Last update timestamp           |
+
+**RLS Policies:**
+
+- Users can SELECT, INSERT, UPDATE, DELETE their own rows only
+
+---
+
+### `research_sessions`
+
+Chat history per company/board for AI research conversations.
+
+| Column               | Type        | Constraints                                | Description           |
+| -------------------- | ----------- | ------------------------------------------ | --------------------- |
+| `id`                 | UUID        | PK, DEFAULT gen_random_uuid()              | Unique identifier     |
+| `user_id`            | UUID        | NOT NULL, FK → users                       | Owner of session      |
+| `company_profile_id` | UUID        | FK → company_profiles (ON DELETE SET NULL) | Associated company    |
+| `title`              | TEXT        |                                            | Session title         |
+| `messages`           | JSONB       | NOT NULL, DEFAULT '[]'                     | Chat messages array   |
+| `created_at`         | TIMESTAMPTZ | NOT NULL, DEFAULT now()                    | Created timestamp     |
+| `updated_at`         | TIMESTAMPTZ | NOT NULL, DEFAULT now()                    | Last update timestamp |
+
+**Messages JSONB Structure:**
+
+```json
+[
+  { "role": "user", "content": "Tell me about this company" },
+  { "role": "assistant", "content": "Based on my research..." }
+]
+```
+
+**RLS Policies:**
+
+- Users can SELECT, INSERT, UPDATE, DELETE their own rows only
+
+---
+
+### `resumes`
+
+Stored resume content per user.
+
+| Column       | Type        | Constraints                         | Description                   |
+| ------------ | ----------- | ----------------------------------- | ----------------------------- |
+| `id`         | UUID        | PK, DEFAULT gen_random_uuid()       | Unique identifier             |
+| `user_id`    | UUID        | NOT NULL, FK → users                | Owner of resume               |
+| `title`      | TEXT        | NOT NULL, DEFAULT 'Untitled Resume' | Resume title/version name     |
+| `content`    | TEXT        |                                     | Parsed text content           |
+| `file_url`   | TEXT        |                                     | Storage URL for uploaded file |
+| `file_name`  | TEXT        |                                     | Original file name            |
+| `is_primary` | BOOLEAN     | DEFAULT false                       | Primary resume flag           |
+| `created_at` | TIMESTAMPTZ | NOT NULL, DEFAULT now()             | Created timestamp             |
+| `updated_at` | TIMESTAMPTZ | NOT NULL, DEFAULT now()             | Last update timestamp         |
+
+**RLS Policies:**
+
+- Users can SELECT, INSERT, UPDATE, DELETE their own rows only
+
+**Triggers:**
+
+- `ensure_single_primary_resume`: Ensures only one resume per user has `is_primary = true`
+
+---
+
+### `job_applications`
+
+Tracks Applied/Interviewing/Offer status per job.
+
+| Column               | Type               | Constraints                                | Description                    |
+| -------------------- | ------------------ | ------------------------------------------ | ------------------------------ |
+| `id`                 | UUID               | PK, DEFAULT gen_random_uuid()              | Unique identifier              |
+| `user_id`            | UUID               | NOT NULL, FK → users                       | Owner of application           |
+| `company_profile_id` | UUID               | FK → company_profiles (ON DELETE SET NULL) | Associated company             |
+| `resume_id`          | UUID               | FK → resumes (ON DELETE SET NULL)          | Resume used for application    |
+| `job_title`          | TEXT               | NOT NULL                                   | Position title                 |
+| `job_url`            | TEXT               |                                            | Link to job posting            |
+| `job_description`    | TEXT               |                                            | Job description text           |
+| `status`             | application_status | NOT NULL, DEFAULT 'saved'                  | Current status                 |
+| `applied_at`         | TIMESTAMPTZ        |                                            | When application was submitted |
+| `notes`              | TEXT               |                                            | User's notes                   |
+| `created_at`         | TIMESTAMPTZ        | NOT NULL, DEFAULT now()                    | Created timestamp              |
+| `updated_at`         | TIMESTAMPTZ        | NOT NULL, DEFAULT now()                    | Last update timestamp          |
+
+**application_status ENUM values:**
+
+- `saved` - Job saved, not yet applied
+- `applied` - Application submitted
+- `phone_screen` - Phone screen scheduled/completed
+- `interviewing` - In interview process
+- `offer` - Received offer
+- `rejected` - Application rejected
+- `withdrawn` - User withdrew application
+
+**RLS Policies:**
+
+- Users can SELECT, INSERT, UPDATE, DELETE their own rows only
+
+**Triggers:**
+
+- `set_applied_at`: Auto-sets `applied_at` when status changes to 'applied'
+
+---
+
+## Foreign Key Relationships
+
+| From Table        | Column             | To Table         | Column | On Delete |
+| ----------------- | ------------------ | ---------------- | ------ | --------- |
+| users             | id                 | auth.users       | id     | CASCADE   |
+| company_profiles  | user_id            | users            | id     | CASCADE   |
+| research_sessions | user_id            | users            | id     | CASCADE   |
+| research_sessions | company_profile_id | company_profiles | id     | SET NULL  |
+| resumes           | user_id            | users            | id     | CASCADE   |
+| job_applications  | user_id            | users            | id     | CASCADE   |
+| job_applications  | company_profile_id | company_profiles | id     | SET NULL  |
+| job_applications  | resume_id          | resumes          | id     | SET NULL  |
+
+---
+
+## Indexes
+
+| Table             | Index Name                               | Columns            |
+| ----------------- | ---------------------------------------- | ------------------ |
+| company_profiles  | company_profiles_user_id_idx             | user_id            |
+| research_sessions | research_sessions_user_id_idx            | user_id            |
+| research_sessions | research_sessions_company_profile_id_idx | company_profile_id |
+| resumes           | resumes_user_id_idx                      | user_id            |
+| job_applications  | job_applications_user_id_idx             | user_id            |
+| job_applications  | job_applications_company_profile_id_idx  | company_profile_id |
+| job_applications  | job_applications_status_idx              | status             |
+
+---
+
+## Shared Functions
+
+### `update_updated_at()`
+
+Trigger function that sets `updated_at = now()` on any row update.
+
+### `handle_new_user()`
+
+Trigger function that auto-creates a `users` row when a new `auth.users` record is created (on signup).
+
+---
+
+## Applying Migrations
+
+```bash
+# Local development
+supabase db reset          # Reset and run all migrations
+
+# Push to remote
+supabase db push           # Apply pending migrations to remote
+```

--- a/supabase/migrations/20260303000001_create_users_table.sql
+++ b/supabase/migrations/20260303000001_create_users_table.sql
@@ -1,0 +1,57 @@
+-- Users table: extends Supabase Auth with additional profile fields
+CREATE TABLE users (
+  id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  full_name TEXT,
+  avatar_url TEXT,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Enable Row Level Security
+ALTER TABLE users ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+CREATE POLICY "Users can view own profile"
+  ON users FOR SELECT
+  USING (auth.uid() = id);
+
+CREATE POLICY "Users can update own profile"
+  ON users FOR UPDATE
+  USING (auth.uid() = id);
+
+CREATE POLICY "Users can insert own profile"
+  ON users FOR INSERT
+  WITH CHECK (auth.uid() = id);
+
+-- Trigger to auto-update updated_at
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER users_updated_at
+  BEFORE UPDATE ON users
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();
+
+-- Auto-create user profile on signup
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.users (id, full_name, avatar_url)
+  VALUES (
+    NEW.id,
+    NEW.raw_user_meta_data->>'full_name',
+    NEW.raw_user_meta_data->>'avatar_url'
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION handle_new_user();

--- a/supabase/migrations/20260303000002_create_company_profiles_table.sql
+++ b/supabase/migrations/20260303000002_create_company_profiles_table.sql
@@ -1,0 +1,42 @@
+-- Company profiles: saved companies in user's Research Board
+CREATE TABLE company_profiles (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  company_name TEXT NOT NULL,
+  company_website TEXT,
+  industry TEXT,
+  company_size TEXT,
+  location TEXT,
+  notes TEXT,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Index for faster user lookups
+CREATE INDEX company_profiles_user_id_idx ON company_profiles(user_id);
+
+-- Enable Row Level Security
+ALTER TABLE company_profiles ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies: users can only access their own company profiles
+CREATE POLICY "Users can view own company profiles"
+  ON company_profiles FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own company profiles"
+  ON company_profiles FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own company profiles"
+  ON company_profiles FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own company profiles"
+  ON company_profiles FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- Trigger to auto-update updated_at
+CREATE TRIGGER company_profiles_updated_at
+  BEFORE UPDATE ON company_profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();

--- a/supabase/migrations/20260303000003_create_research_sessions_table.sql
+++ b/supabase/migrations/20260303000003_create_research_sessions_table.sql
@@ -1,0 +1,40 @@
+-- Research sessions: chat history per company/board
+CREATE TABLE research_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  company_profile_id UUID REFERENCES company_profiles(id) ON DELETE SET NULL,
+  title TEXT,
+  messages JSONB DEFAULT '[]'::jsonb NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Indexes for faster lookups
+CREATE INDEX research_sessions_user_id_idx ON research_sessions(user_id);
+CREATE INDEX research_sessions_company_profile_id_idx ON research_sessions(company_profile_id);
+
+-- Enable Row Level Security
+ALTER TABLE research_sessions ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies: users can only access their own research sessions
+CREATE POLICY "Users can view own research sessions"
+  ON research_sessions FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own research sessions"
+  ON research_sessions FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own research sessions"
+  ON research_sessions FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own research sessions"
+  ON research_sessions FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- Trigger to auto-update updated_at
+CREATE TRIGGER research_sessions_updated_at
+  BEFORE UPDATE ON research_sessions
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();

--- a/supabase/migrations/20260303000004_create_resumes_table.sql
+++ b/supabase/migrations/20260303000004_create_resumes_table.sql
@@ -1,0 +1,59 @@
+-- Resumes: stored resume content per user
+CREATE TABLE resumes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title TEXT NOT NULL DEFAULT 'Untitled Resume',
+  content TEXT,
+  file_url TEXT,
+  file_name TEXT,
+  is_primary BOOLEAN DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Index for faster user lookups
+CREATE INDEX resumes_user_id_idx ON resumes(user_id);
+
+-- Enable Row Level Security
+ALTER TABLE resumes ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies: users can only access their own resumes
+CREATE POLICY "Users can view own resumes"
+  ON resumes FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own resumes"
+  ON resumes FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own resumes"
+  ON resumes FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own resumes"
+  ON resumes FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- Trigger to auto-update updated_at
+CREATE TRIGGER resumes_updated_at
+  BEFORE UPDATE ON resumes
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();
+
+-- Function to ensure only one primary resume per user
+CREATE OR REPLACE FUNCTION ensure_single_primary_resume()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.is_primary = true THEN
+    UPDATE resumes
+    SET is_primary = false
+    WHERE user_id = NEW.user_id AND id != NEW.id AND is_primary = true;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER ensure_single_primary_resume_trigger
+  BEFORE INSERT OR UPDATE ON resumes
+  FOR EACH ROW
+  EXECUTE FUNCTION ensure_single_primary_resume();

--- a/supabase/migrations/20260303000005_create_job_applications_table.sql
+++ b/supabase/migrations/20260303000005_create_job_applications_table.sql
@@ -1,0 +1,72 @@
+-- Job applications: tracks Applied/Interviewing/Offer status per job
+CREATE TYPE application_status AS ENUM (
+  'saved',
+  'applied',
+  'phone_screen',
+  'interviewing',
+  'offer',
+  'rejected',
+  'withdrawn'
+);
+
+CREATE TABLE job_applications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  company_profile_id UUID REFERENCES company_profiles(id) ON DELETE SET NULL,
+  resume_id UUID REFERENCES resumes(id) ON DELETE SET NULL,
+  job_title TEXT NOT NULL,
+  job_url TEXT,
+  job_description TEXT,
+  status application_status DEFAULT 'saved' NOT NULL,
+  applied_at TIMESTAMPTZ,
+  notes TEXT,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Indexes for faster lookups
+CREATE INDEX job_applications_user_id_idx ON job_applications(user_id);
+CREATE INDEX job_applications_company_profile_id_idx ON job_applications(company_profile_id);
+CREATE INDEX job_applications_status_idx ON job_applications(status);
+
+-- Enable Row Level Security
+ALTER TABLE job_applications ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies: users can only access their own job applications
+CREATE POLICY "Users can view own job applications"
+  ON job_applications FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own job applications"
+  ON job_applications FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own job applications"
+  ON job_applications FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own job applications"
+  ON job_applications FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- Trigger to auto-update updated_at
+CREATE TRIGGER job_applications_updated_at
+  BEFORE UPDATE ON job_applications
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();
+
+-- Auto-set applied_at when status changes to 'applied'
+CREATE OR REPLACE FUNCTION set_applied_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.status = 'applied' AND OLD.status != 'applied' AND NEW.applied_at IS NULL THEN
+    NEW.applied_at = now();
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER job_applications_set_applied_at
+  BEFORE UPDATE ON job_applications
+  FOR EACH ROW
+  EXECUTE FUNCTION set_applied_at();

--- a/supabase/migrations/20260303000006_add_email_to_users.sql
+++ b/supabase/migrations/20260303000006_add_email_to_users.sql
@@ -1,0 +1,23 @@
+-- Add email column to users table (IF NOT EXISTS for idempotency)
+ALTER TABLE public.users ADD COLUMN IF NOT EXISTS email TEXT;
+
+-- Backfill existing users with their email from auth.users
+UPDATE public.users
+SET email = au.email
+FROM auth.users au
+WHERE public.users.id = au.id;
+
+-- Update the handle_new_user function to include email
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.users (id, email, full_name, avatar_url)
+  VALUES (
+    NEW.id,
+    NEW.email,
+    NEW.raw_user_meta_data->>'full_name',
+    NEW.raw_user_meta_data->>'avatar_url'
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary

Implements the Supabase PostgreSQL database schema for Uncooked. Creates all required tables with RLS policies and documents the schema.

Closes #25 

## Changes

### Migrations Added
- `20260303000001_create_users_table.sql` — User profiles extending auth.users
- `20260303000002_create_company_profiles_table.sql` — Research Board companies
- `20260303000003_create_research_sessions_table.sql` — Chat history per company
- `20260303000004_create_resumes_table.sql` — Stored resume content
- `20260303000005_create_job_applications_table.sql` — Application status tracking
- `20260303000006_add_email_to_users.sql` — Add email field to users

### Documentation
- Added `docs/DATABASE_SCHEMA.md` with full schema documentation and ER diagram

## Checklist

- [x] All tables defined with column names, types, and constraints
- [x] Foreign key relationships documented
- [x] RLS policies written for each table (users can only access their own data)
- [x] Schema reviewed and approved by at least one other backend team member (by @jeslynyang1121 )
- [x] Migrations applied to Supabase dev environment

## Testing

```bash
supabase db reset  # Apply migrations locally
```
