### PR TITLE
fix: add SPA fallback rewrite to fix 404 on page refresh

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,8 @@
   "framework": "vite",
   "buildCommand": "pnpm build --filter=@uncooked/web",
   "outputDirectory": "apps/web/dist",
-  "installCommand": "pnpm install"
+  "installCommand": "pnpm install",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
 }


### PR DESCRIPTION
Problem:
When users refresh the page or navigate directly to a URL like /dashboard, Vercel returns a 404 because it looks for a static file at that path.

Solution:
Added a rewrite rule to serve index.html for all routes, allowing React Router to handle client-side routing:

```
"rewrites": [
  { "source": "/(.*)", "destination": "/index.html" }
]
```

Testing:
Vite's development server has built-in SPA fallback by default, which is why I wasn't seeing this issue happen in the dev server.
See: https://vite.dev/config/shared-options.html#apptype