### PR TITLE
faster resume tailor + diffs

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,2 +1,2 @@
 VITE_SUPABASE_URL=https://llevroaersgfwhbuiwkl.supabase.co
-VITE_SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
+VITE_SUPABASE_PUBLISHABLE_KEY=sb_publishable_yuXnoBH3R4rioyDusajNwg_YQrEA0fq

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,2 +1,2 @@
 VITE_SUPABASE_URL=https://llevroaersgfwhbuiwkl.supabase.co
-VITE_SUPABASE_PUBLISHABLE_KEY=sb_publishable_yuXnoBH3R4rioyDusajNwg_YQrEA0fq
+VITE_SUPABASE_PUBLISHABLE_KEY=sb_publishable_...

--- a/apps/web/src/hooks/useResumeTailor.ts
+++ b/apps/web/src/hooks/useResumeTailor.ts
@@ -2,6 +2,27 @@ import { useCallback, useState } from 'react'
 import { supabase } from '@/lib/supabase'
 import type { ResumeTailorRequest, ResumeTailorResponse } from '@/types'
 
+const DEBUG_ENABLED = import.meta.env.VITE_RESUME_TAILOR_DEBUG === 'true'
+const DEBUG_VERBOSE = import.meta.env.VITE_RESUME_TAILOR_DEBUG_VERBOSE === 'true'
+
+const toDebugPreview = (value: unknown, maxChars = 1200): string => {
+  try {
+    const serialized = typeof value === 'string' ? value : JSON.stringify(value)
+    if (serialized.length <= maxChars) return serialized
+    return `${serialized.slice(0, maxChars)}... [truncated ${serialized.length - maxChars} chars]`
+  } catch {
+    return '[unserializable]'
+  }
+}
+
+const debugLog = (event: string, data?: Record<string, unknown>) => {
+  if (!DEBUG_ENABLED) return
+  console.log('resume-tailor.client', {
+    event,
+    ...data,
+  })
+}
+
 type UseResumeTailorReturn = {
   runTailor: (payload: ResumeTailorRequest) => Promise<ResumeTailorResponse>
   isLoading: boolean
@@ -82,6 +103,15 @@ export function useResumeTailor(): UseResumeTailorReturn {
     setIsLoading(true)
     setError(null)
 
+    const clientRequestId = Math.random().toString(36).slice(2, 10)
+    debugLog('request_start', {
+      clientRequestId,
+      mode: payload.mode ?? 'delta_only',
+      jobDescriptionChars: payload.jobDescription.length,
+      resumeObjectChars: JSON.stringify(payload.resumeContent).length,
+      payloadPreview: DEBUG_VERBOSE ? toDebugPreview(payload) : undefined,
+    })
+
     try {
       const invokeTailor = async () =>
         supabase.functions.invoke<ResumeTailorResponse>('resume-tailor', {
@@ -90,13 +120,29 @@ export function useResumeTailor(): UseResumeTailorReturn {
 
       let { data, error } = await invokeTailor()
 
+      debugLog('request_result', {
+        clientRequestId,
+        hasData: Boolean(data),
+        hasError: Boolean(error),
+        errorMessage: error?.message,
+        dataPreview: DEBUG_VERBOSE ? toDebugPreview(data) : undefined,
+      })
+
       const message = error?.message ?? ''
       if (error && /invalid jwt/i.test(message)) {
+        debugLog('jwt_refresh_attempt', { clientRequestId })
         const { error: refreshError } = await supabase.auth.refreshSession()
         if (refreshError) throw refreshError
         const retry = await invokeTailor()
         data = retry.data
         error = retry.error
+        debugLog('jwt_refresh_result', {
+          clientRequestId,
+          hasData: Boolean(data),
+          hasError: Boolean(error),
+          errorMessage: error?.message,
+          dataPreview: DEBUG_VERBOSE ? toDebugPreview(data) : undefined,
+        })
       }
 
       if (error) throw error
@@ -104,10 +150,20 @@ export function useResumeTailor(): UseResumeTailorReturn {
         throw new Error('resume-tailor returned no data')
       }
 
+      debugLog('request_success', {
+        clientRequestId,
+        editCount: data.edits?.length ?? 0,
+      })
+
       return data
     } catch (caughtError) {
       const friendlyMessage = await mapErrorMessage(caughtError)
       setError(friendlyMessage)
+      debugLog('request_failed', {
+        clientRequestId,
+        errorMessage: caughtError instanceof Error ? caughtError.message : String(caughtError),
+        friendlyMessage,
+      })
       throw caughtError
     } finally {
       setIsLoading(false)

--- a/apps/web/src/pages/ResumePage.module.css
+++ b/apps/web/src/pages/ResumePage.module.css
@@ -232,27 +232,6 @@
   line-height: 1.5;
 }
 
-.editReason {
-  margin: 0;
-  font-size: var(--font-sm);
-  color: var(--color-text-secondary);
-}
-
-.editDiffs {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--space-2);
-}
-
-.editBefore,
-.editAfter {
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  padding: var(--space-2);
-  min-height: 56px;
-}
-
-.editBefore p,
 .editAfter p {
   margin: var(--space-1) 0 0;
   font-size: 0.8125rem;

--- a/apps/web/src/pages/ResumePage.module.css
+++ b/apps/web/src/pages/ResumePage.module.css
@@ -232,6 +232,112 @@
   line-height: 1.5;
 }
 
+.editsCard {
+  margin: var(--space-4) var(--space-4) 0;
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+}
+
+.editsHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.editStats {
+  font-size: 0.75rem;
+  color: var(--color-text-tertiary);
+}
+
+.editsList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.editItem {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  display: grid;
+  gap: var(--space-2);
+}
+
+.editItemMeta {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  font-size: 0.75rem;
+  color: var(--color-text-tertiary);
+}
+
+.editReason {
+  margin: 0;
+  font-size: var(--font-sm);
+  color: var(--color-text-secondary);
+}
+
+.editDiffs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-2);
+}
+
+.editBefore,
+.editAfter {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2);
+  min-height: 56px;
+}
+
+.editBefore p,
+.editAfter p {
+  margin: var(--space-1) 0 0;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+  white-space: pre-wrap;
+}
+
+.editAfter {
+  background: var(--color-success-subtle);
+}
+
+.editActions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.editAcceptBtn,
+.editDeclineBtn {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.625rem;
+  font-size: 0.75rem;
+  font-family: inherit;
+  cursor: pointer;
+  background: var(--color-bg);
+}
+
+.editAcceptBtn {
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
+.editAcceptBtn:hover {
+  background: var(--color-success-subtle);
+}
+
+.editDeclineBtn:hover {
+  background: var(--color-bg-subtle);
+}
+
 .resumeDocument {
   padding: var(--space-10) var(--space-12);
   max-width: 680px;

--- a/apps/web/src/pages/ResumePage.module.css
+++ b/apps/web/src/pages/ResumePage.module.css
@@ -264,35 +264,6 @@
   background: var(--color-success-subtle);
 }
 
-.editActions {
-  display: flex;
-  gap: var(--space-2);
-}
-
-.editAcceptBtn,
-.editDeclineBtn {
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  padding: 0.25rem 0.625rem;
-  font-size: 0.75rem;
-  font-family: inherit;
-  cursor: pointer;
-  background: var(--color-bg);
-}
-
-.editAcceptBtn {
-  border-color: var(--color-success);
-  color: var(--color-success);
-}
-
-.editAcceptBtn:hover {
-  background: var(--color-success-subtle);
-}
-
-.editDeclineBtn:hover {
-  background: var(--color-bg-subtle);
-}
-
 .resumeDocument {
   padding: var(--space-10) var(--space-12);
   max-width: 680px;

--- a/apps/web/src/pages/ResumePage.module.css
+++ b/apps/web/src/pages/ResumePage.module.css
@@ -232,51 +232,6 @@
   line-height: 1.5;
 }
 
-.editsCard {
-  margin: var(--space-4) var(--space-4) 0;
-  padding: var(--space-3);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  background: var(--color-bg);
-}
-
-.editsHeader {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--space-2);
-  margin-bottom: var(--space-2);
-}
-
-.editStats {
-  font-size: 0.75rem;
-  color: var(--color-text-tertiary);
-}
-
-.editsList {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: var(--space-3);
-}
-
-.editItem {
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: var(--space-3);
-  display: grid;
-  gap: var(--space-2);
-}
-
-.editItemMeta {
-  display: flex;
-  gap: var(--space-2);
-  flex-wrap: wrap;
-  font-size: 0.75rem;
-  color: var(--color-text-tertiary);
-}
-
 .editReason {
   margin: 0;
   font-size: var(--font-sm);

--- a/apps/web/src/pages/ResumePage.tsx
+++ b/apps/web/src/pages/ResumePage.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect, useRef, KeyboardEvent } from 'react'
+import { useState, useRef, KeyboardEvent } from 'react'
 import html2pdf from 'html2pdf.js'
 import { Download, Sparkles, Search, X, Plus, FileUp } from 'lucide-react'
-import { Button, Badge } from '@/components/ui'
+import { Button } from '@/components/ui'
 import { useResumeTailor } from '@/hooks/useResumeTailor'
-import type { ResumeTailorRequest } from '@/types'
+import type { ResumeTailorEdit, ResumeTailorRequest, ResumeTailorResumeContent } from '@/types'
 import { cn } from '@/utils/cn'
 import styles from './ResumePage.module.css'
 
@@ -12,7 +12,7 @@ interface ExperienceEntry {
   title: string
   company: string
   period: string
-  bullets: string[]
+  bullets: ResumeTextItem[]
 }
 
 interface EducationEntry {
@@ -20,6 +20,11 @@ interface EducationEntry {
   degree: string
   school: string
   period: string
+}
+
+interface ResumeTextItem {
+  id: string
+  text: string
 }
 
 const MOCK_RESUME = {
@@ -36,8 +41,14 @@ const MOCK_EXPERIENCE: ExperienceEntry[] = [
     company: 'TechNova Solutions',
     period: '2021 – Present',
     bullets: [
-      'Architected and migrated legacy dashboard to React/Next.js, improving page load speeds by 40%.',
-      'Mentored 3 junior developers and established frontend testing standards using Jest and Cypress.',
+      {
+        id: 'e1_b1',
+        text: 'Architected and migrated legacy dashboard to React/Next.js, improving page load speeds by 40%.',
+      },
+      {
+        id: 'e1_b2',
+        text: 'Mentored 3 junior developers and established frontend testing standards using Jest and Cypress.',
+      },
     ],
   },
   {
@@ -46,8 +57,14 @@ const MOCK_EXPERIENCE: ExperienceEntry[] = [
     company: 'Brightwave Inc.',
     period: '2018 – 2021',
     bullets: [
-      'Built reusable component library used across 6 product teams.',
-      'Led accessibility audit — brought WCAG compliance from 60% to 98%.',
+      {
+        id: 'e2_b1',
+        text: 'Built reusable component library used across 6 product teams.',
+      },
+      {
+        id: 'e2_b2',
+        text: 'Led accessibility audit — brought WCAG compliance from 60% to 98%.',
+      },
     ],
   },
 ]
@@ -56,21 +73,160 @@ const MOCK_EDUCATION: EducationEntry[] = [
   { id: 'ed1', degree: 'B.S. Computer Science', school: 'UC San Diego', period: '2014 – 2018' },
 ]
 
+// Stable ID generators (single source of truth)
+const ID_GENERATORS = {
+  profileName: () => 'profile_name',
+  profileContact: () => 'profile_contact',
+  summary: () => 'summary',
+  experienceField: (entryId: string, field: 'title' | 'company' | 'period') =>
+    `experience_${entryId}_${field}`,
+  experienceBullet: (entryId: string, bulletId: string) => `experience_${entryId}_bullet_${bulletId}`,
+  educationField: (entryId: string, field: 'degree' | 'school' | 'period') =>
+    `education_${entryId}_${field}`,
+  skillItem: (skillId: string) => `skill_${skillId}`,
+}
+
+const createId = () => crypto.randomUUID().replace(/-/g, '')
+
+// Inline suggestion renderer: minimal diff block with accept/decline
+interface SuggestionDiffProps {
+  edit: ResumeTailorEdit
+  currentValue: string | null
+  onAccept: () => void
+  onDecline: () => void
+  variant?: 'compact' | 'stacked'
+}
+
+const SuggestionDiff = ({ edit, currentValue, onAccept, onDecline, variant = 'compact' }: SuggestionDiffProps) => {
+  if (variant === 'stacked') {
+    return (
+      <div style={{ borderLeft: '3px solid #4f46e5', paddingLeft: '0.75rem', marginTop: '0.5rem' }}>
+        <div style={{ fontSize: '0.75rem', fontWeight: 500, color: '#666', marginBottom: '0.5rem' }}>
+          AI Suggestion:
+        </div>
+        <div
+          style={{
+            display: 'grid',
+            gap: '0.75rem',
+            marginBottom: '0.75rem',
+            fontSize: '0.875rem',
+          }}
+        >
+          <div style={{ padding: '0.75rem', backgroundColor: '#f5f5f5', borderRadius: '4px' }}>
+            <strong style={{ display: 'block', fontSize: '0.75rem', marginBottom: '0.25rem', color: '#999' }}>
+              Current
+            </strong>
+            <p style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+              {currentValue ?? '(not found)'}
+            </p>
+          </div>
+          <div style={{ padding: '0.75rem', backgroundColor: '#f0f9ff', borderRadius: '4px' }}>
+            <strong style={{ display: 'block', fontSize: '0.75rem', marginBottom: '0.25rem', color: '#166534' }}>
+              Proposed
+            </strong>
+            <p style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+              {edit.replacement}
+            </p>
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <button
+            onClick={onAccept}
+            style={{
+              padding: '0.375rem 0.75rem',
+              fontSize: '0.75rem',
+              backgroundColor: '#10b981',
+              color: 'white',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: 'pointer',
+            }}
+          >
+            Accept
+          </button>
+          <button
+            onClick={onDecline}
+            style={{
+              padding: '0.375rem 0.75rem',
+              fontSize: '0.75rem',
+              backgroundColor: '#ef4444',
+              color: 'white',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: 'pointer',
+            }}
+          >
+            Decline
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  // compact variant for bullets: single line current → proposed
+  return (
+    <div style={{ borderLeft: '3px solid #4f46e5', paddingLeft: '0.75rem', marginTop: '0.25rem', fontSize: '0.8125rem' }}>
+      <div style={{ marginBottom: '0.25rem', color: '#666' }}>
+        <span style={{ textDecoration: 'line-through', color: '#7f1d1d' }}>{currentValue}</span>
+        <span style={{ margin: '0 0.25rem' }}>→</span>
+        <span style={{ color: '#166534' }}>{edit.replacement}</span>
+      </div>
+      <div style={{ display: 'flex', gap: '0.375rem' }}>
+        <button
+          onClick={onAccept}
+          style={{
+            padding: '0.25rem 0.5rem',
+            fontSize: '0.7rem',
+            backgroundColor: '#10b981',
+            color: 'white',
+            border: 'none',
+            borderRadius: '3px',
+            cursor: 'pointer',
+          }}
+        >
+          Accept
+        </button>
+        <button
+          onClick={onDecline}
+          style={{
+            padding: '0.25rem 0.5rem',
+            fontSize: '0.7rem',
+            backgroundColor: '#ef4444',
+            color: 'white',
+            border: 'none',
+            borderRadius: '3px',
+            cursor: 'pointer',
+          }}
+        >
+          Decline
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// Get suggestion for a specific targetId
+const getEditForTarget = (targetId: string, edits: ResumeTailorEdit[]): ResumeTailorEdit | null => {
+  return edits.find((e) => e.targetId === targetId) ?? null
+}
+
 export default function ResumePage() {
   const resumeRef = useRef<HTMLDivElement>(null)
+  const [resumeName, setResumeName] = useState(MOCK_RESUME.name)
+  const [resumeContact, setResumeContact] = useState(MOCK_RESUME.contact)
+  const [resumeSummary, setResumeSummary] = useState(MOCK_RESUME.summary)
   const [jobDescription, setJobDescription] = useState('')
-  const [skills, setSkills] = useState<string[]>([
-    'React',
-    'TypeScript',
-    'Node.js',
-    'GraphQL',
-    'Tailwind CSS',
+  const [skills, setSkills] = useState<ResumeTextItem[]>([
+    { id: 's1', text: 'React' },
+    { id: 's2', text: 'TypeScript' },
+    { id: 's3', text: 'Node.js' },
+    { id: 's4', text: 'GraphQL' },
+    { id: 's5', text: 'Tailwind CSS' },
   ])
   const [skillInput, setSkillInput] = useState('')
-  const [isTailored, setIsTailored] = useState(false)
   const [experience, setExperience] = useState<ExperienceEntry[]>(MOCK_EXPERIENCE)
   const [education, setEducation] = useState<EducationEntry[]>(MOCK_EDUCATION)
-  const [suggestions, setSuggestions] = useState<string[]>([])
+  const [pendingEdits, setPendingEdits] = useState<ResumeTailorEdit[]>([])
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [isPreviewMode, setIsPreviewMode] = useState(false)
   const { runTailor, isLoading, error: tailorError, clearError } = useResumeTailor()
@@ -82,6 +238,30 @@ export default function ResumePage() {
     if (!file) return
     console.log('PDF selected:', file.name)
   }
+
+  function updateExperienceField(id: string, field: 'title' | 'company' | 'period', value: string) {
+    setExperience((prev) => prev.map((e) => (e.id === id ? { ...e, [field]: value } : e)))
+  }
+
+  function updateEducationField(id: string, field: 'degree' | 'school' | 'period', value: string) {
+    setEducation((prev) => prev.map((e) => (e.id === id ? { ...e, [field]: value } : e)))
+  }
+
+  function updateBullet(expId: string, bulletId: string, value: string) {
+    setExperience((prev) =>
+      prev.map((e) =>
+        e.id === expId
+          ? {
+              ...e,
+              bullets: e.bullets.map((bullet) =>
+                bullet.id === bulletId ? { ...bullet, text: value } : bullet
+              ),
+            }
+          : e
+      )
+    )
+  }
+
   function addExperience() {
     setExperience((prev) => [
       ...prev,
@@ -90,7 +270,7 @@ export default function ResumePage() {
         title: 'Job Title',
         company: 'Company Name',
         period: 'Year – Year',
-        bullets: ['Describe your responsibilities here.'],
+        bullets: [{ id: `${createId()}_b1`, text: 'Describe your responsibilities here.' }],
       },
     ])
   }
@@ -101,14 +281,21 @@ export default function ResumePage() {
 
   function addBullet(expId: string) {
     setExperience((prev) =>
-      prev.map((e) => (e.id === expId ? { ...e, bullets: [...e.bullets, 'New bullet point.'] } : e))
+      prev.map((e) =>
+        e.id === expId
+          ? {
+              ...e,
+              bullets: [...e.bullets, { id: createId(), text: 'New bullet point.' }],
+            }
+          : e
+      )
     )
   }
 
-  function removeBullet(expId: string, index: number) {
+  function removeBullet(expId: string, bulletId: string) {
     setExperience((prev) =>
       prev.map((e) =>
-        e.id === expId ? { ...e, bullets: e.bullets.filter((_, i) => i !== index) } : e
+        e.id === expId ? { ...e, bullets: e.bullets.filter((bullet) => bullet.id !== bulletId) } : e
       )
     )
   }
@@ -133,38 +320,215 @@ export default function ResumePage() {
     if (e.key === 'Enter') {
       e.preventDefault()
       const trimmed = skillInput.trim()
-      if (trimmed && !skills.includes(trimmed)) setSkills((prev) => [...prev, trimmed])
+      if (trimmed && !skills.some((skill) => skill.text.toLowerCase() === trimmed.toLowerCase())) {
+        setSkills((prev) => [...prev, { id: createId(), text: trimmed }])
+      }
       setSkillInput('')
     }
   }
 
-  function removeSkill(skill: string) {
-    setSkills((prev) => prev.filter((s) => s !== skill))
+  function removeSkill(skillId: string) {
+    setSkills((prev) => prev.filter((skill) => skill.id !== skillId))
   }
 
-  useEffect(() => {
-    if (!isTailored) return
-    const t = setTimeout(() => setIsTailored(false), 10000)
-    return () => clearTimeout(t)
-  }, [isTailored])
+  function getCurrentValueForTarget(targetId: string): string | null {
+    if (targetId === ID_GENERATORS.profileName()) return resumeName
+    if (targetId === ID_GENERATORS.profileContact()) return resumeContact
+    if (targetId === ID_GENERATORS.summary()) return resumeSummary
 
-  function buildResumeContent(): ResumeTailorRequest['resumeContent'] {
+    const expFieldMatch = targetId.match(/^experience_(.+?)_(title|company|period)$/)
+    if (expFieldMatch) {
+      const [, entryId, field] = expFieldMatch
+      const entry = experience.find((e) => e.id === entryId)
+      return entry ? entry[field as 'title' | 'company' | 'period'] : null
+    }
+
+    const expBulletMatch = targetId.match(/^experience_(.+?)_bullet_(.+)$/)
+    if (expBulletMatch) {
+      const [, entryId, bulletId] = expBulletMatch
+      const entry = experience.find((e) => e.id === entryId)
+      return entry?.bullets.find((bullet) => bullet.id === bulletId)?.text ?? null
+    }
+
+    const eduFieldMatch = targetId.match(/^education_(.+?)_(degree|school|period)$/)
+    if (eduFieldMatch) {
+      const [, entryId, field] = eduFieldMatch
+      const entry = education.find((e) => e.id === entryId)
+      return entry ? entry[field as 'degree' | 'school' | 'period'] : null
+    }
+
+    const skillMatch = targetId.match(/^skill_(.+)$/)
+    if (skillMatch) {
+      const skillId = skillMatch[1]
+      return skills.find((skill) => skill.id === skillId)?.text ?? null
+    }
+
+    const legacyMatch = targetId.match(/^exp_(\d+)_bullet_(\d+)$/)
+    if (legacyMatch) {
+      const entry = experience[Number(legacyMatch[1]) - 1]
+      return entry?.bullets[Number(legacyMatch[2]) - 1]?.text ?? null
+    }
+
+    return null
+  }
+
+  function applyEdit(edit: ResumeTailorEdit): boolean {
+    const { targetId, operation, replacement } = edit
+
+    if (targetId === ID_GENERATORS.profileName()) {
+      if (operation === 'replace') setResumeName(replacement)
+      else if (operation === 'insert') setResumeName((prev) => `${prev} ${replacement}`.trim())
+      else setResumeName('')
+      return true
+    }
+
+    if (targetId === ID_GENERATORS.profileContact()) {
+      if (operation === 'replace') setResumeContact(replacement)
+      else if (operation === 'insert') setResumeContact((prev) => `${prev} ${replacement}`.trim())
+      else setResumeContact('')
+      return true
+    }
+
+    if (targetId === ID_GENERATORS.summary()) {
+      if (operation === 'replace') setResumeSummary(replacement)
+      else if (operation === 'insert') setResumeSummary((prev) => `${prev}\n${replacement}`.trim())
+      else setResumeSummary('')
+      return true
+    }
+
+    const expFieldMatch = targetId.match(/^experience_(.+?)_(title|company|period)$/)
+    if (expFieldMatch) {
+      const [, entryId, field] = expFieldMatch
+      const exists = experience.some((e) => e.id === entryId)
+      if (!exists) return false
+      const fieldKey = field as 'title' | 'company' | 'period'
+      if (operation === 'replace') updateExperienceField(entryId, fieldKey, replacement)
+      else if (operation === 'insert') {
+        const current = getCurrentValueForTarget(targetId)
+        updateExperienceField(entryId, fieldKey, `${current ?? ''} ${replacement}`.trim())
+      } else updateExperienceField(entryId, fieldKey, '')
+      return true
+    }
+
+    const expBulletMatch = targetId.match(/^experience_(.+?)_bullet_(.+)$/)
+    if (expBulletMatch) {
+      const [, entryId, bulletId] = expBulletMatch
+      const entry = experience.find((e) => e.id === entryId)
+      if (!entry) return false
+      if (operation === 'replace') {
+        updateBullet(entryId, bulletId, replacement)
+      } else if (operation === 'insert') {
+        setExperience((prev) =>
+          prev.map((e) =>
+            e.id === entryId
+              ? {
+                  ...e,
+                  bullets: (() => {
+                    const idx = e.bullets.findIndex((bullet) => bullet.id === bulletId)
+                    if (idx === -1) return e.bullets
+                    const next = [...e.bullets]
+                    next.splice(idx + 1, 0, { id: createId(), text: replacement })
+                    return next
+                  })(),
+                }
+              : e
+          )
+        )
+      } else {
+        setExperience((prev) =>
+          prev.map((e) =>
+            e.id === entryId
+              ? { ...e, bullets: e.bullets.filter((bullet) => bullet.id !== bulletId) }
+              : e
+          )
+        )
+      }
+      return true
+    }
+
+    const eduFieldMatch = targetId.match(/^education_(.+?)_(degree|school|period)$/)
+    if (eduFieldMatch) {
+      const [, entryId, field] = eduFieldMatch
+      const exists = education.some((e) => e.id === entryId)
+      if (!exists) return false
+      const fieldKey = field as 'degree' | 'school' | 'period'
+      if (operation === 'replace') updateEducationField(entryId, fieldKey, replacement)
+      else if (operation === 'insert') {
+        const current = getCurrentValueForTarget(targetId)
+        updateEducationField(entryId, fieldKey, `${current ?? ''} ${replacement}`.trim())
+      } else updateEducationField(entryId, fieldKey, '')
+      return true
+    }
+
+    const skillMatch = targetId.match(/^skill_(.+)$/)
+    if (skillMatch) {
+      const skillId = skillMatch[1]
+      const idx = skills.findIndex((skill) => skill.id === skillId)
+      if (idx === -1) return false
+      if (operation === 'replace') {
+        setSkills((prev) =>
+          prev.map((skill) => (skill.id === skillId ? { ...skill, text: replacement } : skill))
+        )
+      } else if (operation === 'insert') {
+        setSkills((prev) => [
+          ...prev.slice(0, idx + 1),
+          { id: createId(), text: replacement },
+          ...prev.slice(idx + 1),
+        ])
+      } else {
+        setSkills((prev) => prev.filter((skill) => skill.id !== skillId))
+      }
+      return true
+    }
+
+    return false
+  }
+
+  function acceptEdit(index: number) {
+    const edit = pendingEdits[index]
+    if (edit && applyEdit(edit)) {
+      // suggestion applied
+    }
+    setPendingEdits((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  function declineEdit(index: number) {
+    setPendingEdits((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  const handleAcceptEdit = (index: number) => {
+    acceptEdit(index)
+  }
+
+  const handleDeclineEdit = (index: number) => {
+    declineEdit(index)
+  }
+
+  function buildResumeContent(): ResumeTailorResumeContent {
     return {
-      name: MOCK_RESUME.name,
-      contact: MOCK_RESUME.contact,
-      summary: MOCK_RESUME.summary,
+      name: { id: ID_GENERATORS.profileName(), text: resumeName },
+      contact: { id: ID_GENERATORS.profileContact(), text: resumeContact },
+      summary: { id: ID_GENERATORS.summary(), text: resumeSummary },
       experience: experience.map((entry) => ({
-        title: entry.title,
-        company: entry.company,
-        period: entry.period,
-        bullets: entry.bullets,
+        id: entry.id,
+        title: { id: ID_GENERATORS.experienceField(entry.id, 'title'), text: entry.title },
+        company: { id: ID_GENERATORS.experienceField(entry.id, 'company'), text: entry.company },
+        period: { id: ID_GENERATORS.experienceField(entry.id, 'period'), text: entry.period },
+        bullets: entry.bullets.map((bullet) => ({
+          id: ID_GENERATORS.experienceBullet(entry.id, bullet.id),
+          text: bullet.text,
+        })),
       })),
       education: education.map((entry) => ({
-        degree: entry.degree,
-        school: entry.school,
-        period: entry.period,
+        id: entry.id,
+        degree: { id: ID_GENERATORS.educationField(entry.id, 'degree'), text: entry.degree },
+        school: { id: ID_GENERATORS.educationField(entry.id, 'school'), text: entry.school },
+        period: { id: ID_GENERATORS.educationField(entry.id, 'period'), text: entry.period },
       })),
-      skills,
+      skills: skills.map((skill) => ({
+        id: ID_GENERATORS.skillItem(skill.id),
+        text: skill.text,
+      })),
     }
   }
 
@@ -174,23 +538,20 @@ export default function ResumePage() {
 
     if (jobDescription.trim().length < 200) {
       setSubmitError('Please paste a longer job description (minimum 200 characters).')
-      setIsTailored(false)
       return
     }
 
     const payload: ResumeTailorRequest = {
       jobDescription,
-      skills,
       resumeContent: buildResumeContent(),
-      mode: 'suggestions_only',
+      mode: 'delta_only',
     }
 
     try {
       const result = await runTailor(payload)
-      setSuggestions(result.suggestions)
-      setIsTailored(true)
+      setPendingEdits(result.edits ?? [])
     } catch {
-      setIsTailored(false)
+      // error already set by hook
     }
   }
 
@@ -279,12 +640,12 @@ export default function ResumePage() {
             </div>
             <div className={styles.skillChips}>
               {skills.map((skill) => (
-                <span key={skill} className={styles.skillChip}>
-                  {skill}
+                <span key={skill.id} className={styles.skillChip}>
+                  {skill.text}
                   <button
                     className={styles.skillChipRemove}
-                    onClick={() => removeSkill(skill)}
-                    aria-label={`Remove ${skill}`}
+                    onClick={() => removeSkill(skill.id)}
+                    aria-label={`Remove ${skill.text}`}
                   >
                     <X size={10} />
                   </button>
@@ -301,22 +662,7 @@ export default function ResumePage() {
             </div>
           )}
 
-          {isTailored && (
-            <div className={styles.suggestionsBadge}>
-              <Badge variant="success">AI Suggestions Applied</Badge>
-            </div>
-          )}
 
-          {suggestions.length > 0 && (
-            <div className={styles.suggestionsCard}>
-              <p className={styles.suggestionsTitle}>AI Suggestions</p>
-              <ul className={styles.suggestionsList}>
-                {suggestions.map((suggestion, index) => (
-                  <li key={`${suggestion}-${index}`}>{suggestion}</li>
-                ))}
-              </ul>
-            </div>
-          )}
 
           <div ref={resumeRef} className={styles.resumeDocument}>
             <div className={styles.resumeHeader}>
@@ -324,15 +670,17 @@ export default function ResumePage() {
                 className={styles.resumeName}
                 contentEditable={editable}
                 suppressContentEditableWarning
+                onBlur={(e) => setResumeName(e.currentTarget.textContent?.trim() || '')}
               >
-                {MOCK_RESUME.name}
+                {resumeName}
               </h2>
               <p
                 className={styles.resumeContact}
                 contentEditable={editable}
                 suppressContentEditableWarning
+                onBlur={(e) => setResumeContact(e.currentTarget.textContent?.trim() || '')}
               >
-                {MOCK_RESUME.contact}
+                {resumeContact}
               </p>
             </div>
 
@@ -342,9 +690,25 @@ export default function ResumePage() {
                 className={styles.resumeText}
                 contentEditable={editable}
                 suppressContentEditableWarning
+                onBlur={(e) => setResumeSummary(e.currentTarget.textContent?.trim() || '')}
               >
-                {MOCK_RESUME.summary}
+                {resumeSummary}
               </p>
+              {(() => {
+                const summaryEdit = getEditForTarget(ID_GENERATORS.summary(), pendingEdits)
+                if (summaryEdit) {
+                  return (
+                    <SuggestionDiff
+                      edit={summaryEdit}
+                      currentValue={resumeSummary}
+                      onAccept={() => handleAcceptEdit(pendingEdits.indexOf(summaryEdit))}
+                      onDecline={() => handleDeclineEdit(pendingEdits.indexOf(summaryEdit))}
+                      variant="stacked"
+                    />
+                  )
+                }
+                return null
+              })()}
             </div>
 
             <div className={styles.resumeSection}>
@@ -357,6 +721,7 @@ export default function ResumePage() {
                         className={styles.entryTitle}
                         contentEditable={editable}
                         suppressContentEditableWarning
+                        onBlur={(e) => updateExperienceField(job.id, 'title', e.currentTarget.textContent?.trim() || '')}
                       >
                         {job.title}
                       </span>
@@ -372,6 +737,7 @@ export default function ResumePage() {
                       className={styles.entryPeriod}
                       contentEditable={editable}
                       suppressContentEditableWarning
+                      onBlur={(e) => updateExperienceField(job.id, 'period', e.currentTarget.textContent?.trim() || '')}
                     >
                       {job.period}
                     </span>
@@ -380,24 +746,43 @@ export default function ResumePage() {
                     className={styles.entryCompany}
                     contentEditable={editable}
                     suppressContentEditableWarning
+                    onBlur={(e) => updateExperienceField(job.id, 'company', e.currentTarget.textContent?.trim() || '')}
                   >
                     {job.company}
                   </span>
                   <ul className={styles.entryBullets}>
-                    {job.bullets.map((bullet, i) => (
-                      <li key={i} className={styles.bulletItem}>
-                        <span contentEditable={editable} suppressContentEditableWarning>
-                          {bullet}
-                        </span>
-                        <button
-                          className={cn(styles.bulletRemoveBtn, !editable && styles.btnHidden)}
-                          onClick={() => removeBullet(job.id, i)}
-                          aria-label="Remove bullet"
-                        >
-                          <X size={10} />
-                        </button>
-                      </li>
-                    ))}
+                    {job.bullets.map((bullet) => {
+                      const bulletEdit = getEditForTarget(ID_GENERATORS.experienceBullet(job.id, bullet.id), pendingEdits)
+                      return (
+                        <li key={bullet.id} className={styles.bulletItem}>
+                          <span
+                            contentEditable={editable}
+                            suppressContentEditableWarning
+                            onBlur={(e) =>
+                              updateBullet(job.id, bullet.id, e.currentTarget.textContent?.trim() || '')
+                            }
+                          >
+                            {bullet.text}
+                          </span>
+                          <button
+                            className={cn(styles.bulletRemoveBtn, !editable && styles.btnHidden)}
+                            onClick={() => removeBullet(job.id, bullet.id)}
+                            aria-label="Remove bullet"
+                          >
+                            <X size={10} />
+                          </button>
+                          {bulletEdit && (
+                            <SuggestionDiff
+                              edit={bulletEdit}
+                              currentValue={bullet.text}
+                              onAccept={() => handleAcceptEdit(pendingEdits.indexOf(bulletEdit))}
+                              onDecline={() => handleDeclineEdit(pendingEdits.indexOf(bulletEdit))}
+                              variant="compact"
+                            />
+                          )}
+                        </li>
+                      )
+                    })}
                     {editable && (
                       <button className={styles.addBulletBtn} onClick={() => addBullet(job.id)}>
                         <Plus size={11} /> Add bullet
@@ -423,6 +808,7 @@ export default function ResumePage() {
                         className={styles.entryTitle}
                         contentEditable={editable}
                         suppressContentEditableWarning
+                        onBlur={(e) => updateEducationField(edu.id, 'degree', e.currentTarget.textContent?.trim() || '')}
                       >
                         {edu.degree}
                       </span>
@@ -438,6 +824,7 @@ export default function ResumePage() {
                       className={styles.entryPeriod}
                       contentEditable={editable}
                       suppressContentEditableWarning
+                      onBlur={(e) => updateEducationField(edu.id, 'period', e.currentTarget.textContent?.trim() || '')}
                     >
                       {edu.period}
                     </span>
@@ -446,6 +833,7 @@ export default function ResumePage() {
                     className={styles.entryCompany}
                     contentEditable={editable}
                     suppressContentEditableWarning
+                    onBlur={(e) => updateEducationField(edu.id, 'school', e.currentTarget.textContent?.trim() || '')}
                   >
                     {edu.school}
                   </span>
@@ -457,6 +845,28 @@ export default function ResumePage() {
                 </button>
               )}
             </div>
+
+            {(() => {
+              const skillEdits = pendingEdits.filter((e) => e.section === 'skills')
+              if (skillEdits.length > 0) {
+                return (
+                  <div className={styles.resumeSection}>
+                    <h3 className={styles.sectionHeading}>Suggested Skills</h3>
+                    {skillEdits.map((edit) => (
+                      <SuggestionDiff
+                        key={edit.targetId}
+                        edit={edit}
+                        currentValue={skills.find((s) => ID_GENERATORS.skillItem(s.id) === edit.targetId)?.text ?? null}
+                        onAccept={() => handleAcceptEdit(pendingEdits.indexOf(edit))}
+                        onDecline={() => handleDeclineEdit(pendingEdits.indexOf(edit))}
+                        variant="stacked"
+                      />
+                    ))}
+                  </div>
+                )
+              }
+              return null
+            })()}
           </div>
         </div>
       </div>

--- a/apps/web/src/pages/ResumePage.tsx
+++ b/apps/web/src/pages/ResumePage.tsx
@@ -240,7 +240,7 @@ export default function ResumePage() {
     if (!file) return
 
     // TODO(resume-import): wire real PDF parsing and field extraction in a follow-up PR.
-    setSubmitError(`PDF import for \"${file.name}\" is not implemented yet. Please edit fields manually.`)
+    setSubmitError(`PDF import for "${file.name}" is not implemented yet. Please edit fields manually.`)
     e.currentTarget.value = ''
   }
 

--- a/apps/web/src/pages/ResumePage.tsx
+++ b/apps/web/src/pages/ResumePage.tsx
@@ -167,7 +167,9 @@ const SuggestionDiff = ({ edit, currentValue, onAccept, onDecline, variant = 'co
   return (
     <div style={{ borderLeft: '3px solid #4f46e5', paddingLeft: '0.75rem', marginTop: '0.25rem', fontSize: '0.8125rem' }}>
       <div style={{ marginBottom: '0.25rem', color: '#666' }}>
-        <span style={{ textDecoration: 'line-through', color: '#7f1d1d' }}>{currentValue}</span>
+        <span style={{ textDecoration: 'line-through', color: '#7f1d1d' }}>
+          {currentValue ?? 'Current value unavailable (target may have been removed)'}
+        </span>
         <span style={{ margin: '0 0.25rem' }}>→</span>
         <span style={{ color: '#166534' }}>{edit.replacement}</span>
       </div>
@@ -236,7 +238,10 @@ export default function ResumePage() {
   function handlePdfImport(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
     if (!file) return
-    console.log('PDF selected:', file.name)
+
+    // TODO(resume-import): wire real PDF parsing and field extraction in a follow-up PR.
+    setSubmitError(`PDF import for \"${file.name}\" is not implemented yet. Please edit fields manually.`)
+    e.currentTarget.value = ''
   }
 
   function updateExperienceField(id: string, field: 'title' | 'company' | 'period', value: string) {
@@ -496,12 +501,17 @@ export default function ResumePage() {
     setPendingEdits((prev) => prev.filter((_, i) => i !== index))
   }
 
-  const handleAcceptEdit = (index: number) => {
-    acceptEdit(index)
+  const getPendingEditIndex = (targetId: string) =>
+    pendingEdits.findIndex((edit) => edit.targetId === targetId)
+
+  const handleAcceptEditByTargetId = (targetId: string) => {
+    const idx = getPendingEditIndex(targetId)
+    if (idx !== -1) acceptEdit(idx)
   }
 
-  const handleDeclineEdit = (index: number) => {
-    declineEdit(index)
+  const handleDeclineEditByTargetId = (targetId: string) => {
+    const idx = getPendingEditIndex(targetId)
+    if (idx !== -1) declineEdit(idx)
   }
 
   function buildResumeContent(): ResumeTailorResumeContent {
@@ -570,6 +580,19 @@ export default function ResumePage() {
   }
 
   const editable = !isPreviewMode
+  const mappedSummaryTargetId = ID_GENERATORS.summary()
+  const mappedBulletTargetIds = new Set(
+    experience.flatMap((job) =>
+      job.bullets.map((bullet) => ID_GENERATORS.experienceBullet(job.id, bullet.id))
+    )
+  )
+  const mappedSkillTargetIds = new Set(skills.map((skill) => ID_GENERATORS.skillItem(skill.id)))
+  const mappedTargetIds = new Set<string>([
+    mappedSummaryTargetId,
+    ...Array.from(mappedBulletTargetIds),
+    ...Array.from(mappedSkillTargetIds),
+  ])
+  const unmappedEdits = pendingEdits.filter((edit) => !mappedTargetIds.has(edit.targetId))
 
   return (
     <div className={styles.page}>
@@ -695,14 +718,14 @@ export default function ResumePage() {
                 {resumeSummary}
               </p>
               {(() => {
-                const summaryEdit = getEditForTarget(ID_GENERATORS.summary(), pendingEdits)
+                const summaryEdit = getEditForTarget(mappedSummaryTargetId, pendingEdits)
                 if (summaryEdit) {
                   return (
                     <SuggestionDiff
                       edit={summaryEdit}
                       currentValue={resumeSummary}
-                      onAccept={() => handleAcceptEdit(pendingEdits.indexOf(summaryEdit))}
-                      onDecline={() => handleDeclineEdit(pendingEdits.indexOf(summaryEdit))}
+                      onAccept={() => handleAcceptEditByTargetId(summaryEdit.targetId)}
+                      onDecline={() => handleDeclineEditByTargetId(summaryEdit.targetId)}
                       variant="stacked"
                     />
                   )
@@ -752,7 +775,8 @@ export default function ResumePage() {
                   </span>
                   <ul className={styles.entryBullets}>
                     {job.bullets.map((bullet) => {
-                      const bulletEdit = getEditForTarget(ID_GENERATORS.experienceBullet(job.id, bullet.id), pendingEdits)
+                      const bulletTargetId = ID_GENERATORS.experienceBullet(job.id, bullet.id)
+                      const bulletEdit = getEditForTarget(bulletTargetId, pendingEdits)
                       return (
                         <li key={bullet.id} className={styles.bulletItem}>
                           <span
@@ -775,8 +799,8 @@ export default function ResumePage() {
                             <SuggestionDiff
                               edit={bulletEdit}
                               currentValue={bullet.text}
-                              onAccept={() => handleAcceptEdit(pendingEdits.indexOf(bulletEdit))}
-                              onDecline={() => handleDeclineEdit(pendingEdits.indexOf(bulletEdit))}
+                              onAccept={() => handleAcceptEditByTargetId(bulletEdit.targetId)}
+                              onDecline={() => handleDeclineEditByTargetId(bulletEdit.targetId)}
                               variant="compact"
                             />
                           )}
@@ -847,7 +871,9 @@ export default function ResumePage() {
             </div>
 
             {(() => {
-              const skillEdits = pendingEdits.filter((e) => e.section === 'skills')
+              const skillEdits = pendingEdits.filter(
+                (e) => e.section === 'skills' && mappedSkillTargetIds.has(e.targetId)
+              )
               if (skillEdits.length > 0) {
                 return (
                   <div className={styles.resumeSection}>
@@ -857,8 +883,8 @@ export default function ResumePage() {
                         key={edit.targetId}
                         edit={edit}
                         currentValue={skills.find((s) => ID_GENERATORS.skillItem(s.id) === edit.targetId)?.text ?? null}
-                        onAccept={() => handleAcceptEdit(pendingEdits.indexOf(edit))}
-                        onDecline={() => handleDeclineEdit(pendingEdits.indexOf(edit))}
+                        onAccept={() => handleAcceptEditByTargetId(edit.targetId)}
+                        onDecline={() => handleDeclineEditByTargetId(edit.targetId)}
                         variant="stacked"
                       />
                     ))}
@@ -867,6 +893,22 @@ export default function ResumePage() {
               }
               return null
             })()}
+
+            {unmappedEdits.length > 0 && (
+              <div className={styles.resumeSection}>
+                <h3 className={styles.sectionHeading}>Unmapped Suggestions</h3>
+                {unmappedEdits.map((edit) => (
+                  <SuggestionDiff
+                    key={edit.targetId}
+                    edit={edit}
+                    currentValue={getCurrentValueForTarget(edit.targetId)}
+                    onAccept={() => handleAcceptEditByTargetId(edit.targetId)}
+                    onDecline={() => handleDeclineEditByTargetId(edit.targetId)}
+                    variant="stacked"
+                  />
+                ))}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -17,7 +17,9 @@ export interface PastJobDescription {
 }
 
 export type {
+  ResumeTailorEdit,
   ResumeTailorInputObject,
+  ResumeTailorResumeContent,
   ResumeTailorMode,
   ResumeTailorRequest,
   ResumeTailorResponse,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -17,16 +17,56 @@ export interface ResumeTailorInputObject {
 
 export interface ResumeTailorInputArray extends Array<ResumeTailorInputValue> {}
 
+export interface ResumeTailorTextField {
+	id: string
+	text: string
+}
+
+export interface ResumeTailorBulletField extends ResumeTailorTextField {}
+
+export interface ResumeTailorExperienceEntry {
+	id: string
+	title: ResumeTailorTextField
+	company: ResumeTailorTextField
+	period: ResumeTailorTextField
+	bullets: ResumeTailorBulletField[]
+}
+
+export interface ResumeTailorEducationEntry {
+	id: string
+	degree: ResumeTailorTextField
+	school: ResumeTailorTextField
+	period: ResumeTailorTextField
+}
+
+export interface ResumeTailorResumeContent {
+	name: ResumeTailorTextField
+	contact: ResumeTailorTextField
+	summary: ResumeTailorTextField
+	experience: ResumeTailorExperienceEntry[]
+	education: ResumeTailorEducationEntry[]
+	skills: ResumeTailorTextField[]
+}
+
 export interface ResumeTailorRequest {
 	jobDescription: string
-	resumeContent: string | ResumeTailorInputObject
-	skills?: string[]
+	resumeContent: ResumeTailorResumeContent
 	mode?: ResumeTailorMode
 }
 
-export type ResumeTailorMode = 'suggestions_only' | 'full_rewrite'
+export type ResumeTailorMode = 'delta_only'
+
+export type ResumeTailorEditSection = 'summary' | 'experience' | 'skills'
+
+export interface ResumeTailorEdit {
+	section: ResumeTailorEditSection
+	targetId: string
+	operation: 'replace' | 'insert' | 'remove'
+	replacement: string
+}
 
 export interface ResumeTailorResponse {
-	tailoredResume: string
-	suggestions: string[]
+	edits?: ResumeTailorEdit[]
+	appliedMode?: ResumeTailorMode
+	isPartial?: boolean
 }

--- a/supabase/functions/resume-tailor/ai.ts
+++ b/supabase/functions/resume-tailor/ai.ts
@@ -205,7 +205,7 @@ OUTPUT (strict JSON only):
   "edits": [
     {
       "section": "experience",
-      "targetId": "experience_e1_bullet_1",
+      "targetId": "experience_e1_bullet_e1_b1",
       "operation": "replace",
       "replacement": "Improved bullet text aligned to job keywords"
     }

--- a/supabase/functions/resume-tailor/ai.ts
+++ b/supabase/functions/resume-tailor/ai.ts
@@ -1,4 +1,5 @@
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
+import { DEBUG_ENABLED, DEBUG_VERBOSE, isRecord, toDebugPreview } from './utils.ts'
 
 declare const Deno: {
   env: {
@@ -51,25 +52,12 @@ const ALLOWED_EDIT_SECTIONS = new Set<ResumeTailorEdit['section']>(['summary', '
 const MAX_EXPERIENCE_ENTRIES = 5
 const MAX_BULLETS_PER_EXPERIENCE = 4
 const MAX_SKILL_ITEMS = 20
-const DEBUG_ENABLED = Deno.env.get('RESUME_TAILOR_DEBUG') === 'true'
-const DEBUG_VERBOSE = Deno.env.get('RESUME_TAILOR_DEBUG_VERBOSE') === 'true'
-const DEBUG_PREVIEW_CHARS = 1800
 
 type TailorRunOptions = {
   requestId?: string
 }
 
 type ResumeTextNode = { id: string; text: string }
-
-const toDebugPreview = (value: unknown, maxChars = DEBUG_PREVIEW_CHARS): string => {
-  try {
-    const serialized = typeof value === 'string' ? value : JSON.stringify(value)
-    if (serialized.length <= maxChars) return serialized
-    return `${serialized.slice(0, maxChars)}... [truncated ${serialized.length - maxChars} chars]`
-  } catch {
-    return '[unserializable]'
-  }
-}
 
 const debugLog = (requestId: string | undefined, event: string, data?: Record<string, unknown>) => {
   if (!DEBUG_ENABLED) return
@@ -80,9 +68,6 @@ const debugLog = (requestId: string | undefined, event: string, data?: Record<st
     ...data,
   })
 }
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value)
 
 const asTextNode = (value: unknown): ResumeTextNode | null => {
   if (!isRecord(value)) return null
@@ -417,7 +402,7 @@ const runTailor = async (
     promptChars: prompt.length,
     payloadJobDescriptionChars: payload.jobDescription.length,
     payloadResumeChars: JSON.stringify(payload.resumeContent).length,
-    promptPreview: DEBUG_VERBOSE ? toDebugPreview(prompt) : undefined,
+    promptPreview: DEBUG_VERBOSE ? toDebugPreview(prompt, 1800) : undefined,
   })
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -443,7 +428,7 @@ const runTailor = async (
     debugLog(requestId, 'llm_request', {
       attempt,
       generationConfig,
-      requestBodyPreview: DEBUG_VERBOSE ? toDebugPreview(requestBody) : undefined,
+      requestBodyPreview: DEBUG_VERBOSE ? toDebugPreview(requestBody, 1800) : undefined,
     })
 
     const controller = new AbortController()
@@ -466,7 +451,7 @@ const runTailor = async (
         debugLog(requestId, 'llm_http_error', {
           attempt,
           status: response.status,
-          bodyPreview: toDebugPreview(errorText),
+          bodyPreview: toDebugPreview(errorText, 1800),
         })
         throw new Error(`Gemini API error (${response.status}): ${errorText}`)
       }
@@ -477,7 +462,7 @@ const runTailor = async (
         finishReason:
           (data as { candidates?: Array<{ finishReason?: string }> })?.candidates?.[0]?.finishReason ??
           'unknown',
-        responsePreview: DEBUG_VERBOSE ? toDebugPreview(data) : undefined,
+        responsePreview: DEBUG_VERBOSE ? toDebugPreview(data, 1800) : undefined,
       })
 
       const parsed = parseGeminiResponse(data)
@@ -507,7 +492,7 @@ const runTailor = async (
       debugLog(requestId, 'parse_success', {
         attempt,
         editCount: parsed.value.edits?.length ?? 0,
-        resultPreview: DEBUG_VERBOSE ? toDebugPreview(parsed.value) : undefined,
+        resultPreview: DEBUG_VERBOSE ? toDebugPreview(parsed.value, 1800) : undefined,
       })
 
       return parsed.value

--- a/supabase/functions/resume-tailor/ai.ts
+++ b/supabase/functions/resume-tailor/ai.ts
@@ -296,7 +296,8 @@ const parseEdits = (value: unknown): ResumeTailorEdit[] | null => {
     const replacement = typeof edit.replacement === 'string' ? edit.replacement.trim() : ''
     const reason = typeof edit.reason === 'string' ? edit.reason.trim() : undefined
 
-    if (!section || !targetId || !operation || !replacement) continue
+    if (!section || !targetId || !operation) continue
+    if (operation !== 'remove' && !replacement) continue
     if (!ALLOWED_EDIT_SECTIONS.has(section)) continue
     edits.push({ section, targetId, operation, replacement, reason })
   }

--- a/supabase/functions/resume-tailor/ai.ts
+++ b/supabase/functions/resume-tailor/ai.ts
@@ -8,14 +8,24 @@ declare const Deno: {
 
 export type ResumeTailorPayload = {
   jobDescription: string
-  resumeContent: string | Record<string, unknown>
-  skills?: string[]
-  mode?: 'suggestions_only' | 'full_rewrite'
+  resumeContent: Record<string, unknown>
+  mode?: 'delta_only'
 }
 
+export type ResumeTailorEdit = {
+  section: 'summary' | 'experience' | 'skills'
+  targetId: string
+  operation: 'replace' | 'insert' | 'remove'
+  replacement: string
+  reason?: string
+}
+
+export type ResumeTailorMode = 'delta_only'
+
 export type ResumeTailorResult = {
-  tailoredResume: string
-  suggestions: string[]
+  edits?: ResumeTailorEdit[]
+  appliedMode?: ResumeTailorMode
+  isPartial?: boolean
 }
 
 type ParseFailureReason =
@@ -34,83 +44,188 @@ type ParseGeminiResult =
 const GEMINI_MODEL = 'gemini-2.5-flash'
 const GEMINI_API_ENDPOINT = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`
 const MAX_RETRIES = 2
-const TIMEOUT_MS = 60_000
-const SUGGESTIONS_ONLY_BASE_OUTPUT_TOKENS = 2200
-const SUGGESTIONS_ONLY_MAX_OUTPUT_TOKENS = 3400
+const TIMEOUT_MS = 25_000
+const DELTA_ONLY_BASE_OUTPUT_TOKENS = 4000
+const DELTA_ONLY_MAX_OUTPUT_TOKENS = 8000
+const ALLOWED_EDIT_SECTIONS = new Set<ResumeTailorEdit['section']>(['summary', 'experience', 'skills'])
+const MAX_EXPERIENCE_ENTRIES = 5
+const MAX_BULLETS_PER_EXPERIENCE = 4
+const MAX_SKILL_ITEMS = 20
+const DEBUG_ENABLED = Deno.env.get('RESUME_TAILOR_DEBUG') === 'true'
+const DEBUG_VERBOSE = Deno.env.get('RESUME_TAILOR_DEBUG_VERBOSE') === 'true'
+const DEBUG_PREVIEW_CHARS = 1800
 
-const getMode = (mode: ResumeTailorPayload['mode']) =>
-  mode === 'suggestions_only' ? 'suggestions_only' : 'full_rewrite'
-
-const buildPrompt = (payload: ResumeTailorPayload): string => {
-  const mode = getMode(payload.mode)
-  let resumeText = ''
-  if (typeof payload.resumeContent === 'string') {
-    resumeText = payload.resumeContent
-  } else {
-    try {
-      resumeText = JSON.stringify(payload.resumeContent, null, 2)
-    } catch {
-      resumeText = String(payload.resumeContent)
-    }
-  }
-
-  const skillsSection = payload.skills?.length
-    ? `\n\nUser-specified skills to emphasize:\n${payload.skills.join(', ')}`
-    : ''
-
-  if (mode === 'suggestions_only') {
-    return `You are an ATS resume optimizer.
-
-TASK:
-Return 5-7 quick, high-impact suggestions that improve this resume for the job.
-
-RULES:
-- Do not invent facts, dates, metrics, or credentials.
-- Use only information already present in the resume.
-- Each suggestion must be one sentence and at most 18 words.
-- Prioritize missing job keywords, weak bullets, and measurable-impact opportunities.
-- No markdown, numbering, or extra commentary.
-
-JOB DESCRIPTION:
-${payload.jobDescription}
-${skillsSection}
-
-CURRENT RESUME:
-${resumeText}
-
-OUTPUT (strict JSON only):
-{"tailoredResume":"","suggestions":["suggestion 1","suggestion 2","suggestion 3"]}`
-  }
-
-  return `You are an expert resume writer specializing in STAR-format bullet points and ATS optimization.
-
-CRITICAL INSTRUCTIONS:
-- Do NOT invent companies, dates, metrics, degrees, or any factual information
-- ONLY rewrite and reframe existing content
-- Use STAR format (Situation/Task, Action, Result) for experience bullets
-- If metrics are missing, use qualitative results without fabricating numbers
-- Emphasize skills and keywords from the job description
-- Keep section structure intact
-- Be concise and professional
-
-MODE: full_rewrite
-- Return a complete tailored resume in "tailoredResume".
-- Suggestion count: 3 to 6.
-
-JOB DESCRIPTION:
-${payload.jobDescription}
-${skillsSection}
-
-CURRENT RESUME:
-${resumeText}
-
-OUTPUT FORMAT (strict JSON):
-{
-  "tailoredResume": "full rewritten resume text with STAR bullets and job-relevant keywords",
-  "suggestions": ["suggestion 1", "suggestion 2", "suggestion 3"]
+type TailorRunOptions = {
+  requestId?: string
 }
 
-Return ONLY valid JSON. No markdown, no code blocks, no explanations.`
+type ResumeTextNode = { id: string; text: string }
+
+const toDebugPreview = (value: unknown, maxChars = DEBUG_PREVIEW_CHARS): string => {
+  try {
+    const serialized = typeof value === 'string' ? value : JSON.stringify(value)
+    if (serialized.length <= maxChars) return serialized
+    return `${serialized.slice(0, maxChars)}... [truncated ${serialized.length - maxChars} chars]`
+  } catch {
+    return '[unserializable]'
+  }
+}
+
+const debugLog = (requestId: string | undefined, event: string, data?: Record<string, unknown>) => {
+  if (!DEBUG_ENABLED) return
+
+  console.log('resume-tailor.ai', {
+    requestId,
+    event,
+    ...data,
+  })
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const asTextNode = (value: unknown): ResumeTextNode | null => {
+  if (!isRecord(value)) return null
+
+  const id = typeof value.id === 'string' ? value.id.trim() : ''
+  const text = typeof value.text === 'string' ? value.text.trim() : ''
+  if (!id || !text) return null
+
+  return { id, text }
+}
+
+const collectIds = (value: unknown, out: string[] = []): string[] => {
+  if (Array.isArray(value)) {
+    for (const item of value) collectIds(item, out)
+    return out
+  }
+
+  if (!isRecord(value)) return out
+
+  const id = typeof value.id === 'string' ? value.id.trim() : ''
+  if (id) out.push(id)
+
+  for (const nested of Object.values(value)) collectIds(nested, out)
+  return out
+}
+
+const buildLeanResumeContext = (resumeContent: Record<string, unknown>) => {
+  const summary = asTextNode(resumeContent.summary)
+
+  const skills = Array.isArray(resumeContent.skills)
+    ? resumeContent.skills.map(asTextNode).filter((item): item is ResumeTextNode => item !== null)
+    : []
+
+  const experience = Array.isArray(resumeContent.experience)
+    ? resumeContent.experience
+        .slice(0, MAX_EXPERIENCE_ENTRIES)
+        .map((rawEntry) => {
+          if (!isRecord(rawEntry)) return null
+
+          const id = typeof rawEntry.id === 'string' ? rawEntry.id.trim() : ''
+          const title = asTextNode(rawEntry.title)
+          const company = asTextNode(rawEntry.company)
+          const bullets = Array.isArray(rawEntry.bullets)
+            ? rawEntry.bullets
+                .slice(0, MAX_BULLETS_PER_EXPERIENCE)
+                .map(asTextNode)
+                .filter((item): item is ResumeTextNode => item !== null)
+            : []
+
+          if (!id || !title || !company || bullets.length === 0) return null
+
+          return {
+            id,
+            title,
+            company,
+            bullets,
+          }
+        })
+        .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+    : []
+
+  return {
+    summary,
+    skills: skills.slice(0, MAX_SKILL_ITEMS),
+    experience,
+  }
+}
+
+const RESPONSE_SCHEMA = {
+  type: 'OBJECT',
+  required: ['edits'],
+  properties: {
+    edits: {
+      type: 'ARRAY',
+      minItems: 1,
+      maxItems: 5,
+      items: {
+        type: 'OBJECT',
+        required: ['section', 'targetId', 'operation', 'replacement'],
+        properties: {
+          section: {
+            type: 'STRING',
+            enum: ['summary', 'experience', 'skills'],
+          },
+          targetId: { type: 'STRING' },
+          operation: {
+            type: 'STRING',
+            enum: ['replace', 'insert', 'remove'],
+          },
+          replacement: { type: 'STRING' },
+        },
+      },
+    },
+  },
+} as const
+
+const buildPrompt = (payload: ResumeTailorPayload): string => {
+  // Keep the context compact to reduce token pressure and truncation risk.
+  const leanResume = buildLeanResumeContext(payload.resumeContent)
+  const resumeText = JSON.stringify(leanResume)
+  const validTargetIds = JSON.stringify(collectIds(leanResume))
+
+  return `You are a resume tailoring engine that outputs minimal edit deltas.
+
+TASK:
+Return only the highest-impact changes to align the resume with the job description.
+
+RULES:
+- Return valid JSON only.
+- Do not include reasoning, commentary, notes, markdown, code fences, or extra keys.
+- Do not return the full resume.
+- Return changed content only.
+- Preserve original facts and chronology.
+- Do not invent metrics, tools, experiences, achievements, or credentials.
+- Focus only on summary, skills, and selected experience bullets.
+- Return 2-5 edits total.
+- Keep replacement text concise and directly usable.
+
+EDIT TARGETS:
+- section: one of summary|experience|skills
+- operation: replace|insert|remove
+- targetId: MUST be one of VALID_TARGET_IDS (never create new ids)
+
+JOB DESCRIPTION:
+${payload.jobDescription}
+
+CURRENT RESUME (trimmed context):
+${resumeText}
+
+VALID_TARGET_IDS:
+${validTargetIds}
+
+OUTPUT (strict JSON only):
+{
+  "edits": [
+    {
+      "section": "experience",
+      "targetId": "experience_e1_bullet_1",
+      "operation": "replace",
+      "replacement": "Improved bullet text aligned to job keywords"
+    }
+  ]
+}`
 }
 
 const cleanModelText = (text: string): string =>
@@ -176,21 +291,32 @@ const parseJsonObject = (text: string): unknown | null => {
   }
 }
 
-const parseSuggestions = (value: unknown): string[] | null => {
-  if (Array.isArray(value) && value.every((v) => typeof v === 'string')) {
-    const normalized = value.map((item) => item.trim()).filter(Boolean)
-    return normalized.length > 0 ? normalized : null
+const parseEdits = (value: unknown): ResumeTailorEdit[] | null => {
+  if (!Array.isArray(value)) return null
+
+  const edits: ResumeTailorEdit[] = []
+  const sectionValues: ResumeTailorEdit['section'][] = ['summary', 'experience', 'skills']
+
+  for (const rawEdit of value) {
+    if (!rawEdit || typeof rawEdit !== 'object') continue
+
+    const edit = rawEdit as Record<string, unknown>
+    const rawSection = typeof edit.section === 'string' ? edit.section.trim() : ''
+    const section = sectionValues.find((candidate) => candidate === rawSection)
+    const targetId = typeof edit.targetId === 'string' ? edit.targetId.trim() : ''
+    const operation =
+      edit.operation === 'replace' || edit.operation === 'insert' || edit.operation === 'remove'
+        ? edit.operation
+        : null
+    const replacement = typeof edit.replacement === 'string' ? edit.replacement.trim() : ''
+    const reason = typeof edit.reason === 'string' ? edit.reason.trim() : undefined
+
+    if (!section || !targetId || !operation || !replacement) continue
+    if (!ALLOWED_EDIT_SECTIONS.has(section)) continue
+    edits.push({ section, targetId, operation, replacement, reason })
   }
 
-  if (typeof value === 'string') {
-    const normalized = value
-      .split(/\r?\n/)
-      .map((line) => line.replace(/^[-*\d.)\s]+/, '').trim())
-      .filter(Boolean)
-    return normalized.length > 0 ? normalized : null
-  }
-
-  return null
+  return edits.length > 0 ? edits : null
 }
 
 const parseGeminiResponse = (response: unknown): ParseGeminiResult => {
@@ -242,52 +368,60 @@ const parseGeminiResponse = (response: unknown): ParseGeminiResult => {
   }
 
   const result = parsed as {
-    tailoredResume?: unknown
-    suggestions?: unknown
-    recommendations?: unknown
+    edits?: unknown
   }
 
-  const tailoredResume = typeof result.tailoredResume === 'string' ? result.tailoredResume : ''
-  const suggestions = parseSuggestions(result.suggestions) ?? parseSuggestions(result.recommendations)
+  const edits = parseEdits(result.edits)
 
-  if (!suggestions) {
+  if (!edits) {
     return {
       ok: false,
       reason: 'invalid_shape',
-      details: 'Missing string[] suggestions/recommendations in parsed JSON',
+      details: 'delta_only mode requires edits[]',
     }
   }
 
   return {
     ok: true,
     value: {
-      tailoredResume,
-      suggestions,
+      edits,
     },
   }
 }
 
-export const tailorResumeWithAI = async (
-  payload: ResumeTailorPayload
+const getGenerationConfig = (attempt: number) => ({
+  temperature: 0.1,
+  maxOutputTokens: Math.min(
+    DELTA_ONLY_BASE_OUTPUT_TOKENS + attempt * 300,
+    DELTA_ONLY_MAX_OUTPUT_TOKENS
+  ),
+})
+
+const runTailor = async (
+  payload: ResumeTailorPayload,
+  options?: TailorRunOptions
 ): Promise<ResumeTailorResult> => {
   const apiKey = Deno.env.get('GEMINI_API_KEY')
   if (!apiKey) {
     throw new Error('Missing GEMINI_API_KEY environment variable')
   }
 
+  const requestId = options?.requestId
   const prompt = buildPrompt(payload)
-  const mode = getMode(payload.mode)
-
   let lastError: Error | null = null
 
+  debugLog(requestId, 'start', {
+    model: GEMINI_MODEL,
+    retries: MAX_RETRIES,
+    timeoutMs: TIMEOUT_MS,
+    promptChars: prompt.length,
+    payloadJobDescriptionChars: payload.jobDescription.length,
+    payloadResumeChars: JSON.stringify(payload.resumeContent).length,
+    promptPreview: DEBUG_VERBOSE ? toDebugPreview(prompt) : undefined,
+  })
+
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const maxOutputTokens =
-      mode === 'suggestions_only'
-        ? Math.min(
-            SUGGESTIONS_ONLY_BASE_OUTPUT_TOKENS + attempt * 600,
-            SUGGESTIONS_ONLY_MAX_OUTPUT_TOKENS
-          )
-        : 4096
+    const generationConfig = getGenerationConfig(attempt)
 
     const requestBody = {
       contents: [
@@ -300,11 +434,17 @@ export const tailorResumeWithAI = async (
         },
       ],
       generationConfig: {
-        temperature: mode === 'suggestions_only' ? 0.4 : 0.7,
-        maxOutputTokens,
+        ...generationConfig,
         responseMimeType: 'application/json',
+        responseSchema: RESPONSE_SCHEMA,
       },
     }
+
+    debugLog(requestId, 'llm_request', {
+      attempt,
+      generationConfig,
+      requestBodyPreview: DEBUG_VERBOSE ? toDebugPreview(requestBody) : undefined,
+    })
 
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS)
@@ -323,10 +463,23 @@ export const tailorResumeWithAI = async (
 
       if (!response.ok) {
         const errorText = await response.text()
+        debugLog(requestId, 'llm_http_error', {
+          attempt,
+          status: response.status,
+          bodyPreview: toDebugPreview(errorText),
+        })
         throw new Error(`Gemini API error (${response.status}): ${errorText}`)
       }
 
       const data = await response.json()
+      debugLog(requestId, 'llm_response', {
+        attempt,
+        finishReason:
+          (data as { candidates?: Array<{ finishReason?: string }> })?.candidates?.[0]?.finishReason ??
+          'unknown',
+        responsePreview: DEBUG_VERBOSE ? toDebugPreview(data) : undefined,
+      })
+
       const parsed = parseGeminiResponse(data)
 
       if (!parsed.ok) {
@@ -338,13 +491,24 @@ export const tailorResumeWithAI = async (
         console.error('resume-tailor parse failure', {
           reason: parsed.reason,
           details: parsed.details,
-          mode,
           attempt,
-          maxOutputTokens,
+          maxOutputTokens: generationConfig.maxOutputTokens,
+        })
+
+        debugLog(requestId, 'parse_failure', {
+          attempt,
+          reason: parsed.reason,
+          details: parsed.details,
         })
 
         throw new Error(failureMessage)
       }
+
+      debugLog(requestId, 'parse_success', {
+        attempt,
+        editCount: parsed.value.edits?.length ?? 0,
+        resultPreview: DEBUG_VERBOSE ? toDebugPreview(parsed.value) : undefined,
+      })
 
       return parsed.value
     } catch (error) {
@@ -357,6 +521,12 @@ export const tailorResumeWithAI = async (
         !message.includes('gemini api error (429)') &&
         (!message.includes('failed to parse') || message.includes('[truncated]'))
 
+      debugLog(requestId, 'attempt_failed', {
+        attempt,
+        message: lastError.message,
+        shouldRetry,
+      })
+
       if (attempt < MAX_RETRIES && shouldRetry) {
         await new Promise((resolve) => setTimeout(resolve, 1000 * (attempt + 1)))
         continue
@@ -364,5 +534,21 @@ export const tailorResumeWithAI = async (
     }
   }
 
+  debugLog(requestId, 'failed_all_attempts', {
+    message: lastError?.message,
+  })
+
   throw lastError || new Error('AI request failed after retries')
+}
+
+export const tailorResumeWithAI = async (
+  payload: ResumeTailorPayload,
+  options?: TailorRunOptions
+): Promise<ResumeTailorResult> => {
+  const result = await runTailor(payload, options)
+  return {
+    ...result,
+    appliedMode: 'delta_only',
+    isPartial: false,
+  }
 }

--- a/supabase/functions/resume-tailor/index.ts
+++ b/supabase/functions/resume-tailor/index.ts
@@ -1,6 +1,6 @@
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
 import { corsHeaders } from '../_shared/cors.ts'
-import { tailorResumeWithAI, type ResumeTailorPayload } from './ai.ts'
+import { tailorResumeWithAI, type ResumeTailorEdit, type ResumeTailorPayload } from './ai.ts'
 
 declare const Deno: {
   env: {
@@ -12,11 +12,30 @@ declare const Deno: {
 const MAX_BODY_BYTES = 80_000
 const MIN_JOB_DESCRIPTION_CHARS = 200
 const MAX_JOB_DESCRIPTION_CHARS = 12_000
-const MIN_RESUME_TEXT_CHARS = 200
-const MAX_RESUME_TEXT_CHARS = 20_000
 const MAX_RESUME_OBJECT_CHARS = 30_000
-const MAX_SKILLS = 30
-const MAX_SKILL_CHARS = 40
+const DEBUG_ENABLED = Deno.env.get('RESUME_TAILOR_DEBUG') === 'true'
+const DEBUG_VERBOSE = Deno.env.get('RESUME_TAILOR_DEBUG_VERBOSE') === 'true'
+const DEBUG_PREVIEW_CHARS = 1500
+
+const toDebugPreview = (value: unknown, maxChars = DEBUG_PREVIEW_CHARS): string => {
+  try {
+    const serialized = typeof value === 'string' ? value : JSON.stringify(value)
+    if (serialized.length <= maxChars) return serialized
+    return `${serialized.slice(0, maxChars)}... [truncated ${serialized.length - maxChars} chars]`
+  } catch {
+    return '[unserializable]'
+  }
+}
+
+const debugLog = (requestId: string, event: string, data?: Record<string, unknown>) => {
+  if (!DEBUG_ENABLED) return
+
+  console.log('resume-tailor.http', {
+    requestId,
+    event,
+    ...data,
+  })
+}
 
 const json = (status: number, body: unknown) =>
   new Response(JSON.stringify(body), {
@@ -27,30 +46,59 @@ const json = (status: number, body: unknown) =>
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
 
+const collectKnownTargetIds = (value: unknown, targetIds: Set<string> = new Set()): Set<string> => {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectKnownTargetIds(item, targetIds)
+    }
+    return targetIds
+  }
+
+  if (!isRecord(value)) return targetIds
+
+  const maybeId = value.id
+  if (typeof maybeId === 'string' && maybeId.trim()) {
+    targetIds.add(maybeId.trim())
+  }
+
+  for (const nested of Object.values(value)) {
+    collectKnownTargetIds(nested, targetIds)
+  }
+
+  return targetIds
+}
+
+const filterResolvableEdits = (edits: ResumeTailorEdit[] | undefined, targetIds: Set<string>) => {
+  if (!edits?.length) return []
+
+  const filtered = edits.filter((edit) => targetIds.has(edit.targetId))
+
+  if (filtered.length !== edits.length) {
+    console.warn('resume-tailor dropped unresolved edits', {
+      before: edits.length,
+      after: filtered.length,
+    })
+  }
+
+  return filtered
+}
+
 const normalizeBody = (payload: unknown): ResumeTailorPayload | null => {
   if (!isRecord(payload)) return null
 
-  const { jobDescription, resumeContent, skills } = payload
+  const { jobDescription, resumeContent } = payload
   const mode = payload.mode
   if (typeof jobDescription !== 'string') return null
 
-  const isResumeString = typeof resumeContent === 'string'
-  const isResumeObject = isRecord(resumeContent)
-  if (!isResumeString && !isResumeObject) return null
+  if (!isRecord(resumeContent)) return null
 
-  if (skills !== undefined) {
-    if (!Array.isArray(skills)) return null
-    if (!skills.every((skill) => typeof skill === 'string')) return null
-  }
-
-  if (mode !== undefined && mode !== 'suggestions_only' && mode !== 'full_rewrite') {
+  if (mode !== undefined && mode !== 'delta_only') {
     return null
   }
 
   return {
     jobDescription,
     resumeContent,
-    skills,
     mode,
   }
 }
@@ -64,35 +112,9 @@ const validatePayload = (payload: ResumeTailorPayload): string | null => {
     return `jobDescription must be at most ${MAX_JOB_DESCRIPTION_CHARS} characters`
   }
 
-  if (typeof payload.resumeContent === 'string') {
-    const resumeText = payload.resumeContent.trim()
-    if (resumeText.length < MIN_RESUME_TEXT_CHARS) {
-      return `resumeContent must be at least ${MIN_RESUME_TEXT_CHARS} characters when provided as text`
-    }
-    if (resumeText.length > MAX_RESUME_TEXT_CHARS) {
-      return `resumeContent must be at most ${MAX_RESUME_TEXT_CHARS} characters when provided as text`
-    }
-  } else {
-    const resumeObjectLength = JSON.stringify(payload.resumeContent).length
-    if (resumeObjectLength > MAX_RESUME_OBJECT_CHARS) {
-      return `resumeContent object is too large (max ${MAX_RESUME_OBJECT_CHARS} characters when stringified)`
-    }
-  }
-
-  if (payload.skills) {
-    if (payload.skills.length > MAX_SKILLS) {
-      return `skills cannot contain more than ${MAX_SKILLS} items`
-    }
-
-    for (const skill of payload.skills) {
-      const normalized = skill.trim()
-      if (!normalized) {
-        return 'skills cannot contain empty values'
-      }
-      if (normalized.length > MAX_SKILL_CHARS) {
-        return `each skill must be at most ${MAX_SKILL_CHARS} characters`
-      }
-    }
+  const resumeObjectLength = JSON.stringify(payload.resumeContent).length
+  if (resumeObjectLength > MAX_RESUME_OBJECT_CHARS) {
+    return `resumeContent object is too large (max ${MAX_RESUME_OBJECT_CHARS} characters when stringified)`
   }
 
   return null
@@ -125,9 +147,17 @@ const getAuthenticatedUserId = async (req: Request): Promise<string | null> => {
 }
 
 Deno.serve(async (req: Request) => {
+  const requestId = crypto.randomUUID().slice(0, 8)
+
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })
   }
+
+  debugLog(requestId, 'request_received', {
+    method: req.method,
+    hasAuthorization: Boolean(req.headers.get('authorization')),
+    contentLength: req.headers.get('content-length') ?? null,
+  })
 
   if (req.method !== 'POST') {
     return json(405, { error: 'Method Not Allowed' })
@@ -148,6 +178,7 @@ Deno.serve(async (req: Request) => {
   try {
     userId = await getAuthenticatedUserId(req)
   } catch (_error) {
+    debugLog(requestId, 'auth_misconfigured')
     return json(500, {
       error: 'Server Misconfiguration',
       details: 'Missing required Supabase environment variables',
@@ -155,6 +186,7 @@ Deno.serve(async (req: Request) => {
   }
 
   if (!userId) {
+    debugLog(requestId, 'auth_failed')
     return json(401, { error: 'Unauthorized' })
   }
 
@@ -162,20 +194,32 @@ Deno.serve(async (req: Request) => {
   try {
     parsedBody = await req.json()
   } catch {
+    debugLog(requestId, 'invalid_json_body')
     return json(400, { error: 'Invalid JSON body' })
   }
 
   const payload = normalizeBody(parsedBody)
   if (!payload) {
+    debugLog(requestId, 'invalid_payload_shape', {
+      payloadPreview: DEBUG_VERBOSE ? toDebugPreview(parsedBody) : undefined,
+    })
     return json(400, {
       error: 'Invalid payload shape',
-      details:
-        'Expected { jobDescription: string, resumeContent: string|object, skills?: string[], mode?: suggestions_only|full_rewrite }',
+      details: 'Expected { jobDescription: string, resumeContent: object, mode?: delta_only }',
     })
   }
 
+  debugLog(requestId, 'payload_normalized', {
+    userId,
+    mode: payload.mode ?? 'delta_only',
+    jobDescriptionChars: payload.jobDescription.length,
+    resumeObjectChars: JSON.stringify(payload.resumeContent).length,
+    payloadPreview: DEBUG_VERBOSE ? toDebugPreview(payload) : undefined,
+  })
+
   const validationError = validatePayload(payload)
   if (validationError) {
+    debugLog(requestId, 'payload_validation_failed', { validationError })
     return json(400, {
       error: 'Validation failed',
       details: validationError,
@@ -185,9 +229,10 @@ Deno.serve(async (req: Request) => {
   // Phase 4: AI tailoring
   let tailorResult
   try {
-    tailorResult = await tailorResumeWithAI(payload)
+    tailorResult = await tailorResumeWithAI(payload, { requestId })
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)
+    debugLog(requestId, 'tailor_failed', { errorMessage })
 
     // Distinguish between client errors and server errors
     if (errorMessage.includes('Missing GEMINI_API_KEY')) {
@@ -247,8 +292,24 @@ Deno.serve(async (req: Request) => {
     })
   }
 
+  const knownTargetIds = collectKnownTargetIds(payload.resumeContent)
+  const resolvedEdits = filterResolvableEdits(tailorResult.edits, knownTargetIds)
+
+  debugLog(requestId, 'tailor_success', {
+    returnedEdits: tailorResult.edits?.length ?? 0,
+    resolvedEdits: resolvedEdits.length,
+    resultPreview: DEBUG_VERBOSE
+      ? toDebugPreview({
+          edits: resolvedEdits,
+          appliedMode: tailorResult.appliedMode,
+          isPartial: tailorResult.isPartial,
+        })
+      : undefined,
+  })
+
   return json(200, {
-    tailoredResume: tailorResult.tailoredResume,
-    suggestions: tailorResult.suggestions,
+    edits: resolvedEdits,
+    appliedMode: tailorResult.appliedMode,
+    isPartial: tailorResult.isPartial,
   })
 })

--- a/supabase/functions/resume-tailor/index.ts
+++ b/supabase/functions/resume-tailor/index.ts
@@ -1,6 +1,7 @@
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { tailorResumeWithAI, type ResumeTailorEdit, type ResumeTailorPayload } from './ai.ts'
+import { DEBUG_ENABLED, DEBUG_VERBOSE, isRecord, toDebugPreview } from './utils.ts'
 
 declare const Deno: {
   env: {
@@ -13,19 +14,6 @@ const MAX_BODY_BYTES = 80_000
 const MIN_JOB_DESCRIPTION_CHARS = 200
 const MAX_JOB_DESCRIPTION_CHARS = 12_000
 const MAX_RESUME_OBJECT_CHARS = 30_000
-const DEBUG_ENABLED = Deno.env.get('RESUME_TAILOR_DEBUG') === 'true'
-const DEBUG_VERBOSE = Deno.env.get('RESUME_TAILOR_DEBUG_VERBOSE') === 'true'
-const DEBUG_PREVIEW_CHARS = 1500
-
-const toDebugPreview = (value: unknown, maxChars = DEBUG_PREVIEW_CHARS): string => {
-  try {
-    const serialized = typeof value === 'string' ? value : JSON.stringify(value)
-    if (serialized.length <= maxChars) return serialized
-    return `${serialized.slice(0, maxChars)}... [truncated ${serialized.length - maxChars} chars]`
-  } catch {
-    return '[unserializable]'
-  }
-}
 
 const debugLog = (requestId: string, event: string, data?: Record<string, unknown>) => {
   if (!DEBUG_ENABLED) return
@@ -43,8 +31,69 @@ const json = (status: number, body: unknown) =>
     headers: { ...corsHeaders, 'Content-Type': 'application/json' },
   })
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value)
+const isTextNode = (value: unknown): value is { id: string; text: string } =>
+  isRecord(value) && typeof value.id === 'string' && typeof value.text === 'string'
+
+const isExperienceEntry = (
+  value: unknown
+): value is {
+  id: string
+  title: { id: string; text: string }
+  company: { id: string; text: string }
+  period: { id: string; text: string }
+  bullets: Array<{ id: string; text: string }>
+} => {
+  if (!isRecord(value)) return false
+
+  return (
+    typeof value.id === 'string' &&
+    isTextNode(value.title) &&
+    isTextNode(value.company) &&
+    isTextNode(value.period) &&
+    Array.isArray(value.bullets) &&
+    value.bullets.every((bullet) => isTextNode(bullet))
+  )
+}
+
+const isEducationEntry = (
+  value: unknown
+): value is {
+  id: string
+  degree: { id: string; text: string }
+  school: { id: string; text: string }
+  period: { id: string; text: string }
+} => {
+  if (!isRecord(value)) return false
+
+  return (
+    typeof value.id === 'string' &&
+    isTextNode(value.degree) &&
+    isTextNode(value.school) &&
+    isTextNode(value.period)
+  )
+}
+
+const isValidResumeContent = (value: unknown): value is Record<string, unknown> => {
+  if (!isRecord(value)) return false
+
+  if (!isTextNode(value.name) || !isTextNode(value.contact) || !isTextNode(value.summary)) {
+    return false
+  }
+
+  if (!Array.isArray(value.experience) || !value.experience.every((entry) => isExperienceEntry(entry))) {
+    return false
+  }
+
+  if (!Array.isArray(value.education) || !value.education.every((entry) => isEducationEntry(entry))) {
+    return false
+  }
+
+  if (!Array.isArray(value.skills) || !value.skills.every((skill) => isTextNode(skill))) {
+    return false
+  }
+
+  return true
+}
 
 const collectKnownTargetIds = (value: unknown, targetIds: Set<string> = new Set()): Set<string> => {
   if (Array.isArray(value)) {
@@ -90,7 +139,7 @@ const normalizeBody = (payload: unknown): ResumeTailorPayload | null => {
   const mode = payload.mode
   if (typeof jobDescription !== 'string') return null
 
-  if (!isRecord(resumeContent)) return null
+  if (!isValidResumeContent(resumeContent)) return null
 
   if (mode !== undefined && mode !== 'delta_only') {
     return null
@@ -205,7 +254,8 @@ Deno.serve(async (req: Request) => {
     })
     return json(400, {
       error: 'Invalid payload shape',
-      details: 'Expected { jobDescription: string, resumeContent: object, mode?: delta_only }',
+      details:
+        'Expected { jobDescription: string, resumeContent: ResumeTailorResumeContent, mode?: delta_only }',
     })
   }
 

--- a/supabase/functions/resume-tailor/utils.ts
+++ b/supabase/functions/resume-tailor/utils.ts
@@ -1,0 +1,23 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
+
+declare const Deno: {
+  env: {
+    get: (key: string) => string | undefined
+  }
+}
+
+export const DEBUG_ENABLED = Deno.env.get('RESUME_TAILOR_DEBUG') === 'true'
+export const DEBUG_VERBOSE = Deno.env.get('RESUME_TAILOR_DEBUG_VERBOSE') === 'true'
+
+export const toDebugPreview = (value: unknown, maxChars = 1500): string => {
+  try {
+    const serialized = typeof value === 'string' ? value : JSON.stringify(value)
+    if (serialized.length <= maxChars) return serialized
+    return `${serialized.slice(0, maxChars)}... [truncated ${serialized.length - maxChars} chars]`
+  } catch {
+    return '[unserializable]'
+  }
+}
+
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)


### PR DESCRIPTION
Detailed Description Provided Below:
Closes [Issue#32](https://github.com/simonlewi5/uncooked/issues/32)

This pull request introduces a major overhaul of the resume tailoring system, focusing on a new "delta-only" mode that outputs minimal, structured edit deltas rather than full rewritten resumes or suggestion lists. The changes span both frontend and backend, introducing new types, a stricter API contract, improved prompt engineering, and extensive debugging/logging features for both client and server. The system now expects and returns only targeted edits, improving reliability, auditability, and integration with the UI.

Key changes include:

**API Contract and Data Model Overhaul**
* The resume tailoring API now exclusively supports a "delta_only" mode, returning an array of minimal edit objects (`ResumeTailorEdit[]`) instead of full rewritten resumes or suggestion strings. The types for resume content and edits are now strictly defined and enforced across both client and server. [[1]](diffhunk://#diff-ecabfdd7e2be0565549135ce454f50ce3db926b4951903c474d35d9037790aeaR20-R71) [[2]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fL11-R29) [[3]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fL37-R213)
* The backend prompt and parsing logic were rewritten to ensure only valid, minimal JSON edit deltas are produced and accepted. The prompt now instructs the LLM to return only concise, actionable changes, and the parser strictly validates the edit structure. [[1]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fL37-R213) [[2]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fL179-R305) [[3]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fL245-R410)

**Frontend Integration and Debugging**
* The React hook `useResumeTailor` and related types were updated to use the new structured resume content and edit delta format, with improved error handling and extensive debug logging (configurable via environment variables). [[1]](diffhunk://#diff-6cbf70eb44da365f6e62b7ff12dc0197f60f4885934f26c9631253e42ad52ea1R5-R25) [[2]](diffhunk://#diff-6cbf70eb44da365f6e62b7ff12dc0197f60f4885934f26c9631253e42ad52ea1R106-R114) [[3]](diffhunk://#diff-6cbf70eb44da365f6e62b7ff12dc0197f60f4885934f26c9631253e42ad52ea1R123-R166) [[4]](diffhunk://#diff-4acc0e46e20a394a55dd80a1e5aab2adf0cc7cab8ef86ab90795ba99c38620a1R20-R22)
* New CSS classes were added for displaying edit reasons and diffs in the UI, supporting the new edit delta workflow.

**Backend Prompt Engineering and Logging**
* The backend now builds a compact "lean" resume context to reduce token pressure, and the prompt enforces strict output rules for the LLM. Extensive debug logging was added throughout the tailoring process, including prompt previews, LLM request/response summaries, and parse results, all gated by debug flags. [[1]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fL37-R213) [[2]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fL303-R434) [[3]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fR452-R468) [[4]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fL341-R498) [[5]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fR2)

**Parameter and Output Controls**
* Output token limits, timeouts, and section/entry caps were adjusted to optimize reliability and prevent runaway outputs. Only summary, experience, and skills sections are now eligible for edits, and edits are capped per request.

These changes lay the foundation for a more robust, auditable, and UI-friendly resume tailoring workflow.

**Most important changes:**

*API and Data Model Changes*
- Switched API to "delta_only" mode, returning structured `ResumeTailorEdit[]` deltas instead of full resumes or suggestions; updated all related types and validation accordingly. [[1]](diffhunk://#diff-ecabfdd7e2be0565549135ce454f50ce3db926b4951903c474d35d9037790aeaR20-R71) [[2]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fL11-R29) [[3]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fL37-R213)
- Enforced strict JSON schema for edits, including allowed sections, operations, and target IDs; parser now rejects any output not conforming to this schema. [[1]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fL37-R213) [[2]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fL179-R305) [[3]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fL245-R410)

*Frontend Integration and Debugging*
- Updated frontend hook and types to use new resume content format and handle edit deltas, with improved error handling and detailed debug logging. [[1]](diffhunk://#diff-6cbf70eb44da365f6e62b7ff12dc0197f60f4885934f26c9631253e42ad52ea1R5-R25) [[2]](diffhunk://#diff-6cbf70eb44da365f6e62b7ff12dc0197f60f4885934f26c9631253e42ad52ea1R106-R114) [[3]](diffhunk://#diff-6cbf70eb44da365f6e62b7ff12dc0197f60f4885934f26c9631253e42ad52ea1R123-R166) [[4]](diffhunk://#diff-4acc0e46e20a394a55dd80a1e5aab2adf0cc7cab8ef86ab90795ba99c38620a1R20-R22)
- Added new CSS classes for displaying edit reasons and diffs in the UI, supporting granular edit display.

*Backend Prompt Engineering and Logging*
- Rewrote backend prompt to enforce minimal, actionable edit deltas; added comprehensive debug logging for prompt, LLM requests/responses, and parse results, all configurable via environment variables. [[1]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fL37-R213) [[2]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fL303-R434) [[3]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fR452-R468) [[4]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fL341-R498) [[5]](diffhunk://#diff-cb01220c464d08798dd9813d968740b24b59bbe8b5ff2410e3c4cde600e0954fR2)

