### PR TITLE
FEAT: Company Logo in Research Board

### DIFF
--- a/supabase/functions/company-logo/index.ts
+++ b/supabase/functions/company-logo/index.ts
@@ -34,13 +34,8 @@ Deno.serve(async (req) => {
     }
 
     const domain = cleanDomain(rawDomain);
-    const clearbitUrl = `https://logo.clearbit.com/${encodeURIComponent(domain)}`
-
-    const logoResponse = await fetch(clearbitUrl, {
-      headers: {
-        'User-Agent': 'Uncooked-Logo-Proxy',
-      },
-    })
+    const googleFaviconUrl = `https://s2.googleusercontent.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=128`
+    const logoResponse = await fetch(googleFaviconUrl);
 
     if (!logoResponse.ok) {
       return new Response('Logo not found', {


### PR DESCRIPTION
Quick fix of the company-logo edge function. When adding new companies in Research Board's search bar, users can paste a link of their target company; this allows the backend to generate a logo for the company. 

I have manually changed the edge function in supabase, so there is no need to push it again. This is strictly for consistency of the code base.