### PR TITLE
91 connect gamification to resume tailoring

### DIFF
--- a/apps/web/src/components/dashboard/GamificationCard.tsx
+++ b/apps/web/src/components/dashboard/GamificationCard.tsx
@@ -1,10 +1,19 @@
+import { useEffect } from 'react'
 import { Trophy } from 'lucide-react'
 import { useGamificationData } from '@/hooks/useGamificationData'
 import { cn } from '@/utils/cn'
 import styles from './GamificationCard.module.css'
 
 export function GamificationCard(): JSX.Element {
-  const { data, isLoading } = useGamificationData()
+  const { data, isLoading, refetch } = useGamificationData()
+
+  useEffect(() => {
+    const onVis = () => {
+      if (document.visibilityState === 'visible') refetch()
+    }
+    document.addEventListener('visibilitychange', onVis)
+    return () => document.removeEventListener('visibilitychange', onVis)
+  }, [refetch])
 
   if (isLoading || !data) {
     return (

--- a/apps/web/src/components/interview/XpToast.module.css
+++ b/apps/web/src/components/interview/XpToast.module.css
@@ -27,6 +27,20 @@
   opacity: 0.85;
 }
 
+.toastAchievement {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+
+.achievementKicker {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.9;
+}
+
 @keyframes xpSlideUp {
   0% {
     opacity: 0;

--- a/apps/web/src/components/interview/XpToast.tsx
+++ b/apps/web/src/components/interview/XpToast.tsx
@@ -1,20 +1,34 @@
-import { useEffect } from 'react'
+import { useEffect, type CSSProperties } from 'react'
+import { cn } from '@/utils/cn'
 import styles from './XpToast.module.css'
 
 interface XpToastProps {
-  xp: number
+  /** When `achievement`, shows badge unlock copy instead of +XP. */
+  variant?: 'xp' | 'achievement'
+  xp?: number
   label: string
+  /** e.g. vertical offset when stacking multiple toasts */
+  style?: CSSProperties
   onDone: () => void
 }
 
-export function XpToast({ xp, label, onDone }: XpToastProps): JSX.Element {
+export function XpToast({ variant = 'xp', xp = 0, label, style, onDone }: XpToastProps): JSX.Element {
   useEffect(() => {
-    const timer = setTimeout(onDone, 2000)
+    const timer = setTimeout(onDone, variant === 'achievement' ? 2600 : 2000)
     return () => clearTimeout(timer)
-  }, [onDone])
+  }, [onDone, variant])
+
+  if (variant === 'achievement') {
+    return (
+      <div className={cn(styles.toast, styles.toastAchievement)} style={style}>
+        <span className={styles.achievementKicker}>Achievement unlocked</span>
+        <span className={styles.label}>{label}</span>
+      </div>
+    )
+  }
 
   return (
-    <div className={styles.toast}>
+    <div className={styles.toast} style={style}>
       <span className={styles.xp}>+{xp} XP</span>
       <span className={styles.label}>{label}</span>
     </div>

--- a/apps/web/src/hooks/useGamificationData.ts
+++ b/apps/web/src/hooks/useGamificationData.ts
@@ -1,117 +1,27 @@
 import { useState, useEffect } from 'react'
-import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/contexts/AuthContext'
-import type { Badge, GamificationData } from '@/types'
-
-// ── XP constants ──────────────────────────────────────────────────────────────
-
-const XP_PER_LEVEL = 200
-const XP_PER_PRACTICE = 50 // completing a mock interview session
-const XP_PER_RESEARCH = 25 // researching a company
-const XP_PER_APPLICATION = 20 // tracking a job application
-
-// ── Tier labels by level ──────────────────────────────────────────────────────
-
-const TIER_THRESHOLDS: readonly [number, string][] = [
-  [0, 'Job Seeker'],
-  [3, 'Candidate'],
-  [6, 'Contender'],
-  [10, 'Interview Ace'],
-  [15, 'Top Talent'],
-]
-
-function getTierLabel(level: number): string {
-  const tier = [...TIER_THRESHOLDS].reverse().find(([threshold]) => level >= threshold)
-  return tier?.[1] ?? 'Job Seeker'
-}
-
-// ── Badge definitions ─────────────────────────────────────────────────────────
-
-interface Counts {
-  practice: number
-  research: number
-  applications: number
-  interviewMessages: number
-  totalXp: number
-}
-
-type BadgeDef = Omit<Badge, 'earned'> & { check: (counts: Counts) => boolean }
-
-const BADGE_DEFS: readonly BadgeDef[] = [
-  {
-    id: 'first_move',
-    label: 'First Move',
-    description: 'Complete your first mock interview',
-    icon: '🎯',
-    check: ({ practice }) => practice >= 1,
-  },
-  {
-    id: 'researcher',
-    label: 'Researcher',
-    description: 'Research 3 companies',
-    icon: '🔬',
-    check: ({ research }) => research >= 3,
-  },
-  {
-    id: 'pipeline_builder',
-    label: 'Pipeline Builder',
-    description: 'Track your first job application',
-    icon: '💼',
-    check: ({ applications }) => applications >= 1,
-  },
-  {
-    id: 'interview_pro',
-    label: 'Interview Pro',
-    description: 'Complete 5 mock interview sessions',
-    icon: '🏆',
-    check: ({ practice }) => practice >= 5,
-  },
-  {
-    id: 'warming_up',
-    label: 'Warming Up',
-    description: 'Send 25 interview messages',
-    icon: '🔥',
-    check: ({ interviewMessages }) => interviewMessages >= 25,
-  },
-  {
-    id: 'marathon_talker',
-    label: 'Marathon Talker',
-    description: 'Send 100 interview messages',
-    icon: '🎙️',
-    check: ({ interviewMessages }) => interviewMessages >= 100,
-  },
-  {
-    id: 'champion',
-    label: 'Champion',
-    description: 'Earn 500 XP total',
-    icon: '⭐',
-    check: ({ totalXp }) => totalXp >= 500,
-  },
-] as const
-
-// ── Hook ──────────────────────────────────────────────────────────────────────
+import { supabase } from '@/lib/supabase'
+import { computeGamificationData, type GamificationSources } from '@/lib/gamification'
+import type { GamificationData } from '@/types'
 
 interface UseGamificationDataReturn {
   data: GamificationData | null
   isLoading: boolean
+  /** Refetch gamification (e.g. after awarding XP elsewhere). */
+  refetch: () => void
 }
 
 /**
- * Derives the user's gamification state from their existing activity.
- *
- * XP is computed from counts across practice_sessions, research_sessions,
- * and job_applications — no additional writes needed. The user_xp_events
- * table (migration 009) is available for future trigger-based awards or
- * admin bonuses, but is not queried here yet.
- *
- * Separation of concerns: computation logic lives here, presentation in
- * GamificationCard. The hook can be replaced with a DB-aggregated version
- * without touching the UI.
+ * Derives the user's gamification state from practice/research/applications counts
+ * plus the `user_xp_events` ledger (interview messages, resume tailoring, etc.).
  */
 export function useGamificationData(): UseGamificationDataReturn {
   const { user, loading: isAuthLoading } = useAuth()
   const [data, setData] = useState<GamificationData | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const [tick, setTick] = useState(0)
+
+  const refetch = () => setTick((t) => t + 1)
 
   useEffect(() => {
     if (isAuthLoading) return
@@ -125,7 +35,6 @@ export function useGamificationData(): UseGamificationDataReturn {
 
     async function fetchGamificationData(): Promise<void> {
       try {
-        // Fire all four queries in parallel — same pattern as useDashboardData
         const [practiceResult, researchResult, applicationsResult, xpEventsResult] = await Promise.all([
           supabase
             .from('practice_sessions')
@@ -139,51 +48,19 @@ export function useGamificationData(): UseGamificationDataReturn {
             .from('job_applications')
             .select('id', { count: 'exact', head: true })
             .eq('user_id', userId),
-          supabase
-            .from('user_xp_events')
-            .select('xp_awarded, event_type')
-            .eq('user_id', userId),
+          supabase.from('user_xp_events').select('xp_awarded, event_type').eq('user_id', userId),
         ])
 
         if (controller.signal.aborted) return
 
-        const practiceCount = practiceResult.count ?? 0
-        const researchCount = researchResult.count ?? 0
-        const appCount = applicationsResult.count ?? 0
-
-        const xpEvents = xpEventsResult.data ?? []
-        const eventXp = xpEvents.reduce((sum, row) => sum + (row.xp_awarded as number), 0)
-        const interviewMessages = xpEvents.filter(r => r.event_type === 'interview_message').length
-
-        const totalXp =
-          practiceCount * XP_PER_PRACTICE +
-          researchCount * XP_PER_RESEARCH +
-          appCount * XP_PER_APPLICATION +
-          eventXp
-
-        const level = Math.floor(totalXp / XP_PER_LEVEL) + 1
-        const xpInLevel = totalXp % XP_PER_LEVEL
-        const xpForNextLevel = XP_PER_LEVEL
-        const progressPct = Math.round((xpInLevel / XP_PER_LEVEL) * 100)
-        const tierLabel = getTierLabel(level)
-
-        const counts: Counts = {
-          practice: practiceCount,
-          research: researchCount,
-          applications: appCount,
-          interviewMessages,
-          totalXp,
+        const sources: GamificationSources = {
+          practiceCount: practiceResult.count ?? 0,
+          researchCount: researchResult.count ?? 0,
+          applicationCount: applicationsResult.count ?? 0,
+          xpEvents: (xpEventsResult.data ?? []) as GamificationSources['xpEvents'],
         }
 
-        const badges: Badge[] = BADGE_DEFS.map((def) => ({
-          id: def.id,
-          label: def.label,
-          description: def.description,
-          icon: def.icon,
-          earned: def.check(counts),
-        }))
-
-        setData({ level, totalXp, xpInLevel, xpForNextLevel, progressPct, tierLabel, badges })
+        setData(computeGamificationData(sources))
       } catch {
         // Gamification is non-critical; a fetch failure doesn't break the Dashboard
       } finally {
@@ -193,7 +70,7 @@ export function useGamificationData(): UseGamificationDataReturn {
 
     void fetchGamificationData()
     return () => controller.abort()
-  }, [user, isAuthLoading])
+  }, [user, isAuthLoading, tick])
 
-  return { data, isLoading }
+  return { data, isLoading, refetch }
 }

--- a/apps/web/src/lib/gamification/awardGamificationEvent.ts
+++ b/apps/web/src/lib/gamification/awardGamificationEvent.ts
@@ -1,0 +1,50 @@
+import type { Badge } from '@/types'
+import { getXpForEventType } from './eventCatalog'
+import { computeGamificationData, diffNewlyEarnedBadges } from './computeGamificationData'
+import { fetchGamificationSources } from './fetchGamificationSources'
+import { recordXpEvent } from './recordXpEvent'
+
+export interface AwardGamificationResult {
+  success: boolean
+  xpAwarded: number
+  newBadges: Badge[]
+}
+
+/**
+ * Records an XP event and returns newly unlocked badges by diffing gamification state.
+ * Runs multiple queries — always call without blocking the UI (`void awardGamificationEvent(...)`).
+ */
+export async function awardGamificationEvent(
+  userId: string,
+  eventType: string,
+  options?: { referenceId?: string | null },
+): Promise<AwardGamificationResult> {
+  const xpAwarded = getXpForEventType(eventType)
+  if (xpAwarded <= 0) {
+    return { success: false, xpAwarded: 0, newBadges: [] }
+  }
+
+  const beforeSources = await fetchGamificationSources(userId)
+  if (!beforeSources) {
+    return { success: false, xpAwarded: 0, newBadges: [] }
+  }
+  const beforeData = computeGamificationData(beforeSources)
+
+  const ok = await recordXpEvent({
+    userId,
+    eventType,
+    referenceId: options?.referenceId,
+  })
+  if (!ok) {
+    return { success: false, xpAwarded: 0, newBadges: [] }
+  }
+
+  const afterSources = await fetchGamificationSources(userId)
+  if (!afterSources) {
+    return { success: true, xpAwarded, newBadges: [] }
+  }
+  const afterData = computeGamificationData(afterSources)
+  const newBadges = diffNewlyEarnedBadges(beforeData, afterData)
+
+  return { success: true, xpAwarded, newBadges }
+}

--- a/apps/web/src/lib/gamification/awardGamificationEvent.ts
+++ b/apps/web/src/lib/gamification/awardGamificationEvent.ts
@@ -10,9 +10,13 @@ export interface AwardGamificationResult {
   newBadges: Badge[]
 }
 
+function failed(): AwardGamificationResult {
+  return { success: false, xpAwarded: 0, newBadges: [] }
+}
+
 /**
- * Records an XP event and returns newly unlocked badges by diffing gamification state.
- * Runs multiple queries — always call without blocking the UI (`void awardGamificationEvent(...)`).
+ * Snapshot → ledger insert → snapshot; returns badges newly earned in this transition.
+ * Intended to be invoked as `void awardGamificationEvent(...)` so UI stays responsive.
  */
 export async function awardGamificationEvent(
   userId: string,
@@ -20,31 +24,20 @@ export async function awardGamificationEvent(
   options?: { referenceId?: string | null },
 ): Promise<AwardGamificationResult> {
   const xpAwarded = getXpForEventType(eventType)
-  if (xpAwarded <= 0) {
-    return { success: false, xpAwarded: 0, newBadges: [] }
-  }
+  if (xpAwarded <= 0) return failed()
 
-  const beforeSources = await fetchGamificationSources(userId)
-  if (!beforeSources) {
-    return { success: false, xpAwarded: 0, newBadges: [] }
-  }
-  const beforeData = computeGamificationData(beforeSources)
+  const beforeSrc = await fetchGamificationSources(userId)
+  if (!beforeSrc) return failed()
+  const before = computeGamificationData(beforeSrc)
 
-  const ok = await recordXpEvent({
-    userId,
-    eventType,
-    referenceId: options?.referenceId,
-  })
-  if (!ok) {
-    return { success: false, xpAwarded: 0, newBadges: [] }
-  }
+  if (!(await recordXpEvent({ userId, eventType, referenceId: options?.referenceId }))) return failed()
 
-  const afterSources = await fetchGamificationSources(userId)
-  if (!afterSources) {
-    return { success: true, xpAwarded, newBadges: [] }
-  }
-  const afterData = computeGamificationData(afterSources)
-  const newBadges = diffNewlyEarnedBadges(beforeData, afterData)
+  const afterSrc = await fetchGamificationSources(userId)
+  if (!afterSrc) return { success: true, xpAwarded, newBadges: [] }
 
-  return { success: true, xpAwarded, newBadges }
+  return {
+    success: true,
+    xpAwarded,
+    newBadges: diffNewlyEarnedBadges(before, computeGamificationData(afterSrc)),
+  }
 }

--- a/apps/web/src/lib/gamification/computeGamificationData.test.ts
+++ b/apps/web/src/lib/gamification/computeGamificationData.test.ts
@@ -9,8 +9,8 @@ import {
   XP_PER_RESEARCH,
 } from './computeGamificationData'
 
-describe('getXpForEventType (resume tailoring actions)', () => {
-  it('returns the configured XP for each resume event type', () => {
+describe('eventCatalog (resume actions)', () => {
+  it('maps each resume event type to its configured XP', () => {
     expect(getXpForEventType(GAMIFICATION_EVENT_TYPES.RESUME_SESSION_UPLOAD)).toBe(30)
     expect(getXpForEventType(GAMIFICATION_EVENT_TYPES.RESUME_AUTO_TAILOR)).toBe(40)
     expect(getXpForEventType(GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT)).toBe(15)
@@ -19,7 +19,7 @@ describe('getXpForEventType (resume tailoring actions)', () => {
 })
 
 describe('computeGamificationData', () => {
-  it('adds resume tailoring XP events into total XP', () => {
+  it('sums resume ledger rows into total XP', () => {
     const data = computeGamificationData({
       practiceCount: 0,
       researchCount: 0,
@@ -34,19 +34,19 @@ describe('computeGamificationData', () => {
     expect(data.totalXp).toBe(95)
   })
 
-  it('combines table-derived XP with ledger event XP', () => {
+  it('adds session-table XP and ledger XP', () => {
     const data = computeGamificationData({
       practiceCount: 2,
       researchCount: 1,
       applicationCount: 1,
       xpEvents: [{ event_type: GAMIFICATION_EVENT_TYPES.RESUME_AUTO_TAILOR, xp_awarded: 40 }],
     })
-    const expected =
-      2 * XP_PER_PRACTICE + 1 * XP_PER_RESEARCH + 1 * XP_PER_APPLICATION + 40
-    expect(data.totalXp).toBe(expected)
+    expect(data.totalXp).toBe(
+      2 * XP_PER_PRACTICE + 1 * XP_PER_RESEARCH + 1 * XP_PER_APPLICATION + 40,
+    )
   })
 
-  it('unlocks resume_on_file after one upload event', () => {
+  it('earns resume_on_file after one upload event', () => {
     const data = computeGamificationData({
       practiceCount: 0,
       researchCount: 0,
@@ -57,7 +57,7 @@ describe('computeGamificationData', () => {
     expect(data.badges.find((b) => b.id === 'tailor_pilot')?.earned).toBe(false)
   })
 
-  it('unlocks edit_adopter after five apply events', () => {
+  it('earns edit_adopter after five apply events', () => {
     const applies = Array.from({ length: 5 }, () => ({
       event_type: GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT,
       xp_awarded: 15,
@@ -72,7 +72,7 @@ describe('computeGamificationData', () => {
     expect(countEventsByType(applies, GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT)).toBe(5)
   })
 
-  it('sumLedgerXp sums xp_awarded across rows', () => {
+  it('sumLedgerXp aggregates xp_awarded', () => {
     const rows = [
       { event_type: GAMIFICATION_EVENT_TYPES.INTERVIEW_MESSAGE, xp_awarded: 1 },
       { event_type: GAMIFICATION_EVENT_TYPES.RESUME_SESSION_UPLOAD, xp_awarded: 30 },

--- a/apps/web/src/lib/gamification/computeGamificationData.test.ts
+++ b/apps/web/src/lib/gamification/computeGamificationData.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { GAMIFICATION_EVENT_TYPES, getXpForEventType } from './eventCatalog'
+import {
+  computeGamificationData,
+  countEventsByType,
+  sumLedgerXp,
+  XP_PER_APPLICATION,
+  XP_PER_PRACTICE,
+  XP_PER_RESEARCH,
+} from './computeGamificationData'
+
+describe('getXpForEventType (resume tailoring actions)', () => {
+  it('returns the configured XP for each resume event type', () => {
+    expect(getXpForEventType(GAMIFICATION_EVENT_TYPES.RESUME_SESSION_UPLOAD)).toBe(30)
+    expect(getXpForEventType(GAMIFICATION_EVENT_TYPES.RESUME_AUTO_TAILOR)).toBe(40)
+    expect(getXpForEventType(GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT)).toBe(15)
+    expect(getXpForEventType(GAMIFICATION_EVENT_TYPES.RESUME_DECLINE_TAILOR_EDIT)).toBe(10)
+  })
+})
+
+describe('computeGamificationData', () => {
+  it('adds resume tailoring XP events into total XP', () => {
+    const data = computeGamificationData({
+      practiceCount: 0,
+      researchCount: 0,
+      applicationCount: 0,
+      xpEvents: [
+        { event_type: GAMIFICATION_EVENT_TYPES.RESUME_SESSION_UPLOAD, xp_awarded: 30 },
+        { event_type: GAMIFICATION_EVENT_TYPES.RESUME_AUTO_TAILOR, xp_awarded: 40 },
+        { event_type: GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT, xp_awarded: 15 },
+        { event_type: GAMIFICATION_EVENT_TYPES.RESUME_DECLINE_TAILOR_EDIT, xp_awarded: 10 },
+      ],
+    })
+    expect(data.totalXp).toBe(95)
+  })
+
+  it('combines table-derived XP with ledger event XP', () => {
+    const data = computeGamificationData({
+      practiceCount: 2,
+      researchCount: 1,
+      applicationCount: 1,
+      xpEvents: [{ event_type: GAMIFICATION_EVENT_TYPES.RESUME_AUTO_TAILOR, xp_awarded: 40 }],
+    })
+    const expected =
+      2 * XP_PER_PRACTICE + 1 * XP_PER_RESEARCH + 1 * XP_PER_APPLICATION + 40
+    expect(data.totalXp).toBe(expected)
+  })
+
+  it('unlocks resume_on_file after one upload event', () => {
+    const data = computeGamificationData({
+      practiceCount: 0,
+      researchCount: 0,
+      applicationCount: 0,
+      xpEvents: [{ event_type: GAMIFICATION_EVENT_TYPES.RESUME_SESSION_UPLOAD, xp_awarded: 30 }],
+    })
+    expect(data.badges.find((b) => b.id === 'resume_on_file')?.earned).toBe(true)
+    expect(data.badges.find((b) => b.id === 'tailor_pilot')?.earned).toBe(false)
+  })
+
+  it('unlocks edit_adopter after five apply events', () => {
+    const applies = Array.from({ length: 5 }, () => ({
+      event_type: GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT,
+      xp_awarded: 15,
+    }))
+    const data = computeGamificationData({
+      practiceCount: 0,
+      researchCount: 0,
+      applicationCount: 0,
+      xpEvents: applies,
+    })
+    expect(data.badges.find((b) => b.id === 'edit_adopter')?.earned).toBe(true)
+    expect(countEventsByType(applies, GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT)).toBe(5)
+  })
+
+  it('sumLedgerXp sums xp_awarded across rows', () => {
+    const rows = [
+      { event_type: GAMIFICATION_EVENT_TYPES.INTERVIEW_MESSAGE, xp_awarded: 1 },
+      { event_type: GAMIFICATION_EVENT_TYPES.RESUME_SESSION_UPLOAD, xp_awarded: 30 },
+    ]
+    expect(sumLedgerXp(rows)).toBe(31)
+  })
+})

--- a/apps/web/src/lib/gamification/computeGamificationData.ts
+++ b/apps/web/src/lib/gamification/computeGamificationData.ts
@@ -1,0 +1,192 @@
+import type { Badge, GamificationData } from '@/types'
+import { GAMIFICATION_EVENT_TYPES } from './eventCatalog'
+
+export const XP_PER_LEVEL = 200
+export const XP_PER_PRACTICE = 50
+export const XP_PER_RESEARCH = 25
+export const XP_PER_APPLICATION = 20
+
+export interface XpEventRow {
+  event_type: string
+  xp_awarded: number
+}
+
+export interface GamificationSources {
+  practiceCount: number
+  researchCount: number
+  applicationCount: number
+  xpEvents: XpEventRow[]
+}
+
+const TIER_THRESHOLDS: readonly [number, string][] = [
+  [0, 'Job Seeker'],
+  [3, 'Candidate'],
+  [6, 'Contender'],
+  [10, 'Interview Ace'],
+  [15, 'Top Talent'],
+]
+
+function getTierLabel(level: number): string {
+  const tier = [...TIER_THRESHOLDS].reverse().find(([threshold]) => level >= threshold)
+  return tier?.[1] ?? 'Job Seeker'
+}
+
+/** Count rows with a given event_type (each row = one action, e.g. one chat message). */
+export function countEventsByType(rows: XpEventRow[], eventType: string): number {
+  return rows.filter((r) => r.event_type === eventType).length
+}
+
+/** Sum of xp_awarded across all ledger rows (interview + resume + future events). */
+export function sumLedgerXp(rows: XpEventRow[]): number {
+  return rows.reduce((sum, row) => sum + (Number(row.xp_awarded) || 0), 0)
+}
+
+interface Counts {
+  practice: number
+  research: number
+  applications: number
+  interviewMessages: number
+  resumeUploads: number
+  resumeTailorRuns: number
+  resumeApplyEdits: number
+  resumeDeclineEdits: number
+  totalXp: number
+}
+
+type BadgeDef = Omit<Badge, 'earned'> & { check: (counts: Counts) => boolean }
+
+const BADGE_DEFS: readonly BadgeDef[] = [
+  {
+    id: 'first_move',
+    label: 'First Move',
+    description: 'Complete your first mock interview',
+    icon: '🎯',
+    check: ({ practice }) => practice >= 1,
+  },
+  {
+    id: 'researcher',
+    label: 'Researcher',
+    description: 'Research 3 companies',
+    icon: '🔬',
+    check: ({ research }) => research >= 3,
+  },
+  {
+    id: 'pipeline_builder',
+    label: 'Pipeline Builder',
+    description: 'Track your first job application',
+    icon: '💼',
+    check: ({ applications }) => applications >= 1,
+  },
+  {
+    id: 'interview_pro',
+    label: 'Interview Pro',
+    description: 'Complete 5 mock interview sessions',
+    icon: '🏆',
+    check: ({ practice }) => practice >= 5,
+  },
+  {
+    id: 'warming_up',
+    label: 'Warming Up',
+    description: 'Send 25 interview messages',
+    icon: '🔥',
+    check: ({ interviewMessages }) => interviewMessages >= 25,
+  },
+  {
+    id: 'marathon_talker',
+    label: 'Marathon Talker',
+    description: 'Send 100 interview messages',
+    icon: '🎙️',
+    check: ({ interviewMessages }) => interviewMessages >= 100,
+  },
+  {
+    id: 'champion',
+    label: 'Champion',
+    description: 'Earn 500 XP total',
+    icon: '⭐',
+    check: ({ totalXp }) => totalXp >= 500,
+  },
+  {
+    id: 'resume_on_file',
+    label: 'Resume on File',
+    description: 'Upload a resume for a tailoring session',
+    icon: '📄',
+    check: ({ resumeUploads }) => resumeUploads >= 1,
+  },
+  {
+    id: 'tailor_pilot',
+    label: 'Tailor Pilot',
+    description: 'Run Auto-Tailor at least once',
+    icon: '✨',
+    check: ({ resumeTailorRuns }) => resumeTailorRuns >= 1,
+  },
+  {
+    id: 'edit_adopter',
+    label: 'Edit Adopter',
+    description: 'Apply 5 tailored suggestions to your resume',
+    icon: '✅',
+    check: ({ resumeApplyEdits }) => resumeApplyEdits >= 5,
+  },
+  {
+    id: 'careful_reviewer',
+    label: 'Careful Reviewer',
+    description: 'Decline at least 3 suggestions you chose not to use',
+    icon: '🧭',
+    check: ({ resumeDeclineEdits }) => resumeDeclineEdits >= 3,
+  },
+] as const
+
+/**
+ * Pure computation from aggregate sources (used by the dashboard hook and tests).
+ */
+export function computeGamificationData(sources: GamificationSources): GamificationData {
+  const { practiceCount, researchCount, applicationCount, xpEvents } = sources
+
+  const eventXp = sumLedgerXp(xpEvents)
+  const interviewMessages = countEventsByType(xpEvents, GAMIFICATION_EVENT_TYPES.INTERVIEW_MESSAGE)
+  const resumeUploads = countEventsByType(xpEvents, GAMIFICATION_EVENT_TYPES.RESUME_SESSION_UPLOAD)
+  const resumeTailorRuns = countEventsByType(xpEvents, GAMIFICATION_EVENT_TYPES.RESUME_AUTO_TAILOR)
+  const resumeApplyEdits = countEventsByType(xpEvents, GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT)
+  const resumeDeclineEdits = countEventsByType(xpEvents, GAMIFICATION_EVENT_TYPES.RESUME_DECLINE_TAILOR_EDIT)
+
+  const totalXp =
+    practiceCount * XP_PER_PRACTICE +
+    researchCount * XP_PER_RESEARCH +
+    applicationCount * XP_PER_APPLICATION +
+    eventXp
+
+  const level = Math.floor(totalXp / XP_PER_LEVEL) + 1
+  const xpInLevel = totalXp % XP_PER_LEVEL
+  const xpForNextLevel = XP_PER_LEVEL
+  const progressPct = Math.round((xpInLevel / XP_PER_LEVEL) * 100)
+  const tierLabel = getTierLabel(level)
+
+  const counts: Counts = {
+    practice: practiceCount,
+    research: researchCount,
+    applications: applicationCount,
+    interviewMessages,
+    resumeUploads,
+    resumeTailorRuns,
+    resumeApplyEdits,
+    resumeDeclineEdits,
+    totalXp,
+  }
+
+  const badges: Badge[] = BADGE_DEFS.map((def) => ({
+    id: def.id,
+    label: def.label,
+    description: def.description,
+    icon: def.icon,
+    earned: def.check(counts),
+  }))
+
+  return { level, totalXp, xpInLevel, xpForNextLevel, progressPct, tierLabel, badges }
+}
+
+export function diffNewlyEarnedBadges(before: GamificationData, after: GamificationData): Badge[] {
+  return after.badges.filter((b) => {
+    if (!b.earned) return false
+    const prev = before.badges.find((x) => x.id === b.id)
+    return !prev?.earned
+  })
+}

--- a/apps/web/src/lib/gamification/computeGamificationData.ts
+++ b/apps/web/src/lib/gamification/computeGamificationData.ts
@@ -31,14 +31,24 @@ function getTierLabel(level: number): string {
   return tier?.[1] ?? 'Job Seeker'
 }
 
-/** Count rows with a given event_type (each row = one action, e.g. one chat message). */
 export function countEventsByType(rows: XpEventRow[], eventType: string): number {
   return rows.filter((r) => r.event_type === eventType).length
 }
 
-/** Sum of xp_awarded across all ledger rows (interview + resume + future events). */
 export function sumLedgerXp(rows: XpEventRow[]): number {
   return rows.reduce((sum, row) => sum + (Number(row.xp_awarded) || 0), 0)
+}
+
+function ledgerCounts(xpEvents: XpEventRow[]) {
+  const n = (t: string) => countEventsByType(xpEvents, t)
+  return {
+    eventXp: sumLedgerXp(xpEvents),
+    interviewMessages: n(GAMIFICATION_EVENT_TYPES.INTERVIEW_MESSAGE),
+    resumeUploads: n(GAMIFICATION_EVENT_TYPES.RESUME_SESSION_UPLOAD),
+    resumeTailorRuns: n(GAMIFICATION_EVENT_TYPES.RESUME_AUTO_TAILOR),
+    resumeApplyEdits: n(GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT),
+    resumeDeclineEdits: n(GAMIFICATION_EVENT_TYPES.RESUME_DECLINE_TAILOR_EDIT),
+  }
 }
 
 interface Counts {
@@ -135,24 +145,16 @@ const BADGE_DEFS: readonly BadgeDef[] = [
   },
 ] as const
 
-/**
- * Pure computation from aggregate sources (used by the dashboard hook and tests).
- */
+/** Derives level, XP, and badges from session counts plus `user_xp_events` rows. */
 export function computeGamificationData(sources: GamificationSources): GamificationData {
   const { practiceCount, researchCount, applicationCount, xpEvents } = sources
-
-  const eventXp = sumLedgerXp(xpEvents)
-  const interviewMessages = countEventsByType(xpEvents, GAMIFICATION_EVENT_TYPES.INTERVIEW_MESSAGE)
-  const resumeUploads = countEventsByType(xpEvents, GAMIFICATION_EVENT_TYPES.RESUME_SESSION_UPLOAD)
-  const resumeTailorRuns = countEventsByType(xpEvents, GAMIFICATION_EVENT_TYPES.RESUME_AUTO_TAILOR)
-  const resumeApplyEdits = countEventsByType(xpEvents, GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT)
-  const resumeDeclineEdits = countEventsByType(xpEvents, GAMIFICATION_EVENT_TYPES.RESUME_DECLINE_TAILOR_EDIT)
+  const ledger = ledgerCounts(xpEvents)
 
   const totalXp =
     practiceCount * XP_PER_PRACTICE +
     researchCount * XP_PER_RESEARCH +
     applicationCount * XP_PER_APPLICATION +
-    eventXp
+    ledger.eventXp
 
   const level = Math.floor(totalXp / XP_PER_LEVEL) + 1
   const xpInLevel = totalXp % XP_PER_LEVEL
@@ -164,11 +166,11 @@ export function computeGamificationData(sources: GamificationSources): Gamificat
     practice: practiceCount,
     research: researchCount,
     applications: applicationCount,
-    interviewMessages,
-    resumeUploads,
-    resumeTailorRuns,
-    resumeApplyEdits,
-    resumeDeclineEdits,
+    interviewMessages: ledger.interviewMessages,
+    resumeUploads: ledger.resumeUploads,
+    resumeTailorRuns: ledger.resumeTailorRuns,
+    resumeApplyEdits: ledger.resumeApplyEdits,
+    resumeDeclineEdits: ledger.resumeDeclineEdits,
     totalXp,
   }
 

--- a/apps/web/src/lib/gamification/eventCatalog.ts
+++ b/apps/web/src/lib/gamification/eventCatalog.ts
@@ -1,14 +1,9 @@
-/**
- * Central catalog for gamification event types and XP amounts.
- * Add new keys here when introducing additional tracked actions.
- */
+/** String identifiers for `user_xp_events.event_type`; XP amounts live in `XP_BY_EVENT_TYPE`. */
 export const GAMIFICATION_EVENT_TYPES = {
-  /** Interview session started (existing) */
   INTERVIEW_START: 'interview_start',
   INTERVIEW_MESSAGE: 'interview_message',
   INTERVIEW_MILESTONE_5: 'interview_milestone_5',
   INTERVIEW_MILESTONE_10: 'interview_milestone_10',
-  /** Resume tailoring workflow */
   RESUME_SESSION_UPLOAD: 'resume_session_upload',
   RESUME_AUTO_TAILOR: 'resume_auto_tailor',
   RESUME_APPLY_TAILOR_EDIT: 'resume_apply_tailor_edit',
@@ -16,15 +11,12 @@ export const GAMIFICATION_EVENT_TYPES = {
 } as const
 
 export type ResumeGamificationEventType =
-  (typeof GAMIFICATION_EVENT_TYPES)[keyof Pick<
-    typeof GAMIFICATION_EVENT_TYPES,
-    | 'RESUME_SESSION_UPLOAD'
-    | 'RESUME_AUTO_TAILOR'
-    | 'RESUME_APPLY_TAILOR_EDIT'
-    | 'RESUME_DECLINE_TAILOR_EDIT'
-  >]
+  | typeof GAMIFICATION_EVENT_TYPES.RESUME_SESSION_UPLOAD
+  | typeof GAMIFICATION_EVENT_TYPES.RESUME_AUTO_TAILOR
+  | typeof GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT
+  | typeof GAMIFICATION_EVENT_TYPES.RESUME_DECLINE_TAILOR_EDIT
 
-/** XP granted per event insert (must match insert payloads). */
+/** Must match `xp_awarded` written at insert time (see `useInterviewChat`, `recordXpEvent`). */
 export const XP_BY_EVENT_TYPE: Record<string, number> = {
   [GAMIFICATION_EVENT_TYPES.INTERVIEW_START]: 5,
   [GAMIFICATION_EVENT_TYPES.INTERVIEW_MESSAGE]: 1,
@@ -36,7 +28,7 @@ export const XP_BY_EVENT_TYPE: Record<string, number> = {
   [GAMIFICATION_EVENT_TYPES.RESUME_DECLINE_TAILOR_EDIT]: 10,
 }
 
-export const TOAST_TITLE_BY_EVENT_TYPE: Record<string, string> = {
+const RESUME_TOAST_TITLE: Partial<Record<ResumeGamificationEventType, string>> = {
   [GAMIFICATION_EVENT_TYPES.RESUME_SESSION_UPLOAD]: 'Resume uploaded',
   [GAMIFICATION_EVENT_TYPES.RESUME_AUTO_TAILOR]: 'Auto-Tailor run',
   [GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT]: 'Suggestion applied',
@@ -48,5 +40,5 @@ export function getXpForEventType(eventType: string): number {
 }
 
 export function getResumeToastTitle(eventType: ResumeGamificationEventType): string {
-  return TOAST_TITLE_BY_EVENT_TYPE[eventType] ?? 'Progress saved'
+  return RESUME_TOAST_TITLE[eventType] ?? 'Progress saved'
 }

--- a/apps/web/src/lib/gamification/eventCatalog.ts
+++ b/apps/web/src/lib/gamification/eventCatalog.ts
@@ -1,0 +1,52 @@
+/**
+ * Central catalog for gamification event types and XP amounts.
+ * Add new keys here when introducing additional tracked actions.
+ */
+export const GAMIFICATION_EVENT_TYPES = {
+  /** Interview session started (existing) */
+  INTERVIEW_START: 'interview_start',
+  INTERVIEW_MESSAGE: 'interview_message',
+  INTERVIEW_MILESTONE_5: 'interview_milestone_5',
+  INTERVIEW_MILESTONE_10: 'interview_milestone_10',
+  /** Resume tailoring workflow */
+  RESUME_SESSION_UPLOAD: 'resume_session_upload',
+  RESUME_AUTO_TAILOR: 'resume_auto_tailor',
+  RESUME_APPLY_TAILOR_EDIT: 'resume_apply_tailor_edit',
+  RESUME_DECLINE_TAILOR_EDIT: 'resume_decline_tailor_edit',
+} as const
+
+export type ResumeGamificationEventType =
+  (typeof GAMIFICATION_EVENT_TYPES)[keyof Pick<
+    typeof GAMIFICATION_EVENT_TYPES,
+    | 'RESUME_SESSION_UPLOAD'
+    | 'RESUME_AUTO_TAILOR'
+    | 'RESUME_APPLY_TAILOR_EDIT'
+    | 'RESUME_DECLINE_TAILOR_EDIT'
+  >]
+
+/** XP granted per event insert (must match insert payloads). */
+export const XP_BY_EVENT_TYPE: Record<string, number> = {
+  [GAMIFICATION_EVENT_TYPES.INTERVIEW_START]: 5,
+  [GAMIFICATION_EVENT_TYPES.INTERVIEW_MESSAGE]: 1,
+  [GAMIFICATION_EVENT_TYPES.INTERVIEW_MILESTONE_5]: 5,
+  [GAMIFICATION_EVENT_TYPES.INTERVIEW_MILESTONE_10]: 10,
+  [GAMIFICATION_EVENT_TYPES.RESUME_SESSION_UPLOAD]: 30,
+  [GAMIFICATION_EVENT_TYPES.RESUME_AUTO_TAILOR]: 40,
+  [GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT]: 15,
+  [GAMIFICATION_EVENT_TYPES.RESUME_DECLINE_TAILOR_EDIT]: 10,
+}
+
+export const TOAST_TITLE_BY_EVENT_TYPE: Record<string, string> = {
+  [GAMIFICATION_EVENT_TYPES.RESUME_SESSION_UPLOAD]: 'Resume uploaded',
+  [GAMIFICATION_EVENT_TYPES.RESUME_AUTO_TAILOR]: 'Auto-Tailor run',
+  [GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT]: 'Suggestion applied',
+  [GAMIFICATION_EVENT_TYPES.RESUME_DECLINE_TAILOR_EDIT]: 'Suggestion declined',
+}
+
+export function getXpForEventType(eventType: string): number {
+  return XP_BY_EVENT_TYPE[eventType] ?? 0
+}
+
+export function getResumeToastTitle(eventType: ResumeGamificationEventType): string {
+  return TOAST_TITLE_BY_EVENT_TYPE[eventType] ?? 'Progress saved'
+}

--- a/apps/web/src/lib/gamification/fetchGamificationSources.ts
+++ b/apps/web/src/lib/gamification/fetchGamificationSources.ts
@@ -2,30 +2,19 @@ import { supabase } from '@/lib/supabase'
 import type { GamificationSources } from './computeGamificationData'
 
 export async function fetchGamificationSources(userId: string): Promise<GamificationSources | null> {
-  const [practiceResult, researchResult, applicationsResult, xpEventsResult] = await Promise.all([
-    supabase
-      .from('practice_sessions')
-      .select('id', { count: 'exact', head: true })
-      .eq('user_id', userId),
-    supabase
-      .from('research_sessions')
-      .select('id', { count: 'exact', head: true })
-      .eq('user_id', userId),
-    supabase
-      .from('job_applications')
-      .select('id', { count: 'exact', head: true })
-      .eq('user_id', userId),
+  const [practice, research, applications, xpEvents] = await Promise.all([
+    supabase.from('practice_sessions').select('id', { count: 'exact', head: true }).eq('user_id', userId),
+    supabase.from('research_sessions').select('id', { count: 'exact', head: true }).eq('user_id', userId),
+    supabase.from('job_applications').select('id', { count: 'exact', head: true }).eq('user_id', userId),
     supabase.from('user_xp_events').select('xp_awarded, event_type').eq('user_id', userId),
   ])
 
-  if (practiceResult.error || researchResult.error || applicationsResult.error || xpEventsResult.error) {
-    return null
-  }
+  if (practice.error || research.error || applications.error || xpEvents.error) return null
 
   return {
-    practiceCount: practiceResult.count ?? 0,
-    researchCount: researchResult.count ?? 0,
-    applicationCount: applicationsResult.count ?? 0,
-    xpEvents: (xpEventsResult.data ?? []) as GamificationSources['xpEvents'],
+    practiceCount: practice.count ?? 0,
+    researchCount: research.count ?? 0,
+    applicationCount: applications.count ?? 0,
+    xpEvents: (xpEvents.data ?? []) as GamificationSources['xpEvents'],
   }
 }

--- a/apps/web/src/lib/gamification/fetchGamificationSources.ts
+++ b/apps/web/src/lib/gamification/fetchGamificationSources.ts
@@ -1,0 +1,31 @@
+import { supabase } from '@/lib/supabase'
+import type { GamificationSources } from './computeGamificationData'
+
+export async function fetchGamificationSources(userId: string): Promise<GamificationSources | null> {
+  const [practiceResult, researchResult, applicationsResult, xpEventsResult] = await Promise.all([
+    supabase
+      .from('practice_sessions')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId),
+    supabase
+      .from('research_sessions')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId),
+    supabase
+      .from('job_applications')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId),
+    supabase.from('user_xp_events').select('xp_awarded, event_type').eq('user_id', userId),
+  ])
+
+  if (practiceResult.error || researchResult.error || applicationsResult.error || xpEventsResult.error) {
+    return null
+  }
+
+  return {
+    practiceCount: practiceResult.count ?? 0,
+    researchCount: researchResult.count ?? 0,
+    applicationCount: applicationsResult.count ?? 0,
+    xpEvents: (xpEventsResult.data ?? []) as GamificationSources['xpEvents'],
+  }
+}

--- a/apps/web/src/lib/gamification/index.ts
+++ b/apps/web/src/lib/gamification/index.ts
@@ -2,6 +2,7 @@ export {
   GAMIFICATION_EVENT_TYPES,
   getResumeToastTitle,
   getXpForEventType,
+  XP_BY_EVENT_TYPE,
   type ResumeGamificationEventType,
 } from './eventCatalog'
 export {
@@ -17,5 +18,5 @@ export {
   type XpEventRow,
 } from './computeGamificationData'
 export { fetchGamificationSources } from './fetchGamificationSources'
-export { recordXpEvent } from './recordXpEvent'
+export { recordXpEvent, type RecordXpEventParams } from './recordXpEvent'
 export { awardGamificationEvent, type AwardGamificationResult } from './awardGamificationEvent'

--- a/apps/web/src/lib/gamification/index.ts
+++ b/apps/web/src/lib/gamification/index.ts
@@ -1,0 +1,21 @@
+export {
+  GAMIFICATION_EVENT_TYPES,
+  getResumeToastTitle,
+  getXpForEventType,
+  type ResumeGamificationEventType,
+} from './eventCatalog'
+export {
+  computeGamificationData,
+  countEventsByType,
+  diffNewlyEarnedBadges,
+  sumLedgerXp,
+  XP_PER_APPLICATION,
+  XP_PER_LEVEL,
+  XP_PER_PRACTICE,
+  XP_PER_RESEARCH,
+  type GamificationSources,
+  type XpEventRow,
+} from './computeGamificationData'
+export { fetchGamificationSources } from './fetchGamificationSources'
+export { recordXpEvent } from './recordXpEvent'
+export { awardGamificationEvent, type AwardGamificationResult } from './awardGamificationEvent'

--- a/apps/web/src/lib/gamification/recordXpEvent.ts
+++ b/apps/web/src/lib/gamification/recordXpEvent.ts
@@ -7,10 +7,7 @@ export interface RecordXpEventParams {
   referenceId?: string | null
 }
 
-/**
- * Inserts one row into the XP ledger. Callers should not await in critical UI paths;
- * use `void recordXpEvent(...)` or `awardGamificationEvent` which batches snapshots.
- */
+/** Inserts one `user_xp_events` row. Prefer `awardGamificationEvent` when UI needs badge diff. */
 export async function recordXpEvent(params: RecordXpEventParams): Promise<boolean> {
   const xp = getXpForEventType(params.eventType)
   if (xp <= 0) return false
@@ -23,7 +20,7 @@ export async function recordXpEvent(params: RecordXpEventParams): Promise<boolea
   })
 
   if (error) {
-    console.error('recordXpEvent failed', params.eventType, error.message)
+    console.error('recordXpEvent', params.eventType, error.message)
     return false
   }
   return true

--- a/apps/web/src/lib/gamification/recordXpEvent.ts
+++ b/apps/web/src/lib/gamification/recordXpEvent.ts
@@ -1,0 +1,30 @@
+import { supabase } from '@/lib/supabase'
+import { getXpForEventType } from './eventCatalog'
+
+export interface RecordXpEventParams {
+  userId: string
+  eventType: string
+  referenceId?: string | null
+}
+
+/**
+ * Inserts one row into the XP ledger. Callers should not await in critical UI paths;
+ * use `void recordXpEvent(...)` or `awardGamificationEvent` which batches snapshots.
+ */
+export async function recordXpEvent(params: RecordXpEventParams): Promise<boolean> {
+  const xp = getXpForEventType(params.eventType)
+  if (xp <= 0) return false
+
+  const { error } = await supabase.from('user_xp_events').insert({
+    user_id: params.userId,
+    event_type: params.eventType,
+    xp_awarded: xp,
+    reference_id: params.referenceId ?? undefined,
+  })
+
+  if (error) {
+    console.error('recordXpEvent failed', params.eventType, error.message)
+    return false
+  }
+  return true
+}

--- a/apps/web/src/pages/ResumePage.tsx
+++ b/apps/web/src/pages/ResumePage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, KeyboardEvent, useCallback } from 'react'
 import html2pdf from 'html2pdf.js'
 import { Download, Sparkles, Search, X, Plus, FileUp } from 'lucide-react'
 import { Button } from '@/components/ui'
+import { XpToast } from '@/components/interview/XpToast'
 import { ResumeSuggestionsPanel } from '@/components/resume/ResumeSuggestionsPanel'
 import {
   applySuggestion,
@@ -32,6 +33,12 @@ import { useResumeTailor } from '@/hooks/useResumeTailor'
 import { useResumeUploadAndParse } from '@/hooks/useResumeUploadAndParse'
 import { useResumePersistence } from '@/hooks/useResumePersistence'
 import { useAuth } from '@/contexts/AuthContext'
+import {
+  awardGamificationEvent,
+  GAMIFICATION_EVENT_TYPES,
+  getResumeToastTitle,
+  type ResumeGamificationEventType,
+} from '@/lib/gamification'
 import type { ResumeDocument, ResumeTailorEdit } from '@/types'
 import { cn } from '@/utils/cn'
 import styles from './ResumePage.module.css'
@@ -146,6 +153,43 @@ export default function ResumePage() {
 
   const pdfInputRef = useRef<HTMLInputElement>(null)
 
+  type GamificationToastItem =
+    | { id: number; variant: 'xp'; xp: number; label: string }
+    | { id: number; variant: 'achievement'; label: string }
+
+  const [gamificationToasts, setGamificationToasts] = useState<GamificationToastItem[]>([])
+
+  const pushGamificationToast = useCallback((item: GamificationToastItem) => {
+    setGamificationToasts((prev) => [...prev, item])
+  }, [])
+
+  const queueResumeGamification = useCallback(
+    (eventType: ResumeGamificationEventType, referenceId?: string | null) => {
+      if (!user?.id) return
+      void awardGamificationEvent(user.id, eventType, { referenceId: referenceId ?? undefined }).then(
+        (result) => {
+          if (!result.success) return
+          pushGamificationToast({
+            id: Date.now() + Math.random(),
+            variant: 'xp',
+            xp: result.xpAwarded,
+            label: getResumeToastTitle(eventType),
+          })
+          result.newBadges.forEach((badge, i) => {
+            window.setTimeout(() => {
+              pushGamificationToast({
+                id: Date.now() + Math.random(),
+                variant: 'achievement',
+                label: `${badge.icon} ${badge.label}`,
+              })
+            }, 320 * (i + 1))
+          })
+        },
+      )
+    },
+    [user?.id, pushGamificationToast],
+  )
+
   // ── Local helpers for contentEditable field updates ──
   const handleUpdateProfileField = (field: 'name' | 'contact', text: string) => {
     setResumeContent((prev) => updateProfileField(prev, field, text))
@@ -216,6 +260,7 @@ export default function ResumePage() {
       setResumeContent(normalizeResumeDocument(saved.structuredContent))
       setActiveResumeId(saved.id)
       setPendingEdits([])
+      queueResumeGamification(GAMIFICATION_EVENT_TYPES.RESUME_SESSION_UPLOAD, saved.id)
       setSubmitError(
         saved.status === 'partial'
           ? 'Resume imported with partial parsing. Please review and edit extracted sections.'
@@ -303,6 +348,7 @@ export default function ResumePage() {
 
     setPendingEdits(result.edits)
     setTailorRunState('complete')
+    queueResumeGamification(GAMIFICATION_EVENT_TYPES.RESUME_AUTO_TAILOR)
   }
 
   async function handleExportPDF() {
@@ -350,18 +396,35 @@ export default function ResumePage() {
 
   const handleAcceptTarget = (targetId: string) => {
     const normalizedTargetId = normalizeTargetId(targetId)
-    applyEditByTargetId(normalizedTargetId)
+    const applied = applyEditByTargetId(normalizedTargetId)
+    if (applied) {
+      queueResumeGamification(GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT)
+    }
     setActiveTargetId((current) => (current === normalizedTargetId ? null : current))
   }
 
   const handleDeclineTarget = (targetId: string) => {
     const normalizedTargetId = normalizeTargetId(targetId)
+    const hadSuggestion = Boolean(findSuggestionByTargetId(pendingEdits, normalizedTargetId))
     setPendingEdits((prev) => removeSuggestionByTargetId(prev, normalizedTargetId))
+    if (hadSuggestion) {
+      queueResumeGamification(GAMIFICATION_EVENT_TYPES.RESUME_DECLINE_TAILOR_EDIT)
+    }
     setActiveTargetId((current) => (current === normalizedTargetId ? null : current))
   }
 
   return (
     <div className={styles.page}>
+      {gamificationToasts.map((t, i) => (
+        <XpToast
+          key={t.id}
+          variant={t.variant}
+          xp={t.variant === 'xp' ? t.xp : undefined}
+          label={t.label}
+          style={{ bottom: `calc(1.5rem + ${i * 3.5}rem)` }}
+          onDone={() => setGamificationToasts((prev) => prev.filter((x) => x.id !== t.id))}
+        />
+      ))}
       <div className={styles.header}>
         <div>
           <h1 className={styles.title}>Resume Editor</h1>


### PR DESCRIPTION
## Summary
Connects resume-tailoring actions to the dashboard gamification card via a small shared `lib/gamification` module.

## Changes
- **`apps/web/src/lib/gamification/`** — Event catalog + XP amounts, pure `computeGamificationData`, `fetchGamificationSources`, `recordXpEvent`, `awardGamificationEvent` (snapshot → insert → diff badges).
- **`ResumePage`** — Awards XP (non-blocking) for: successful resume upload, successful Auto-Tailor, applying a suggestion, declining a suggestion; stacked XP / achievement toasts via extended **`XpToast`**.
- **`useGamificationData`** — Delegates level/XP/badge math to `computeGamificationData`; adds **`refetch()`**.
- **`GamificationCard`** — Refetches when the tab becomes visible so totals/badges update after tailoring elsewhere.

## Notes
- Requires existing `user_xp_events` table and RLS (already in migrations).
- Interview XP inserts remain in `useInterviewChat`; catalog documents matching XP for consistency.