### PR TITLE
complete cohesion between research and interviews

### DIFF
--- a/apps/web/src/components/interview/CompanyHistory.tsx
+++ b/apps/web/src/components/interview/CompanyHistory.tsx
@@ -23,7 +23,7 @@ export function CompanyHistory({ onSelect, onLoadSession }: CompanyHistoryProps)
         .order('company_name', { ascending: true }),
       supabase
         .from('interview_sessions')
-        .select('id, company_name, company_profile_id, interview_style, created_at, resume_id')
+        .select('id, company_name, company_profile_id, company_role_id, interview_style, created_at, resume_id')
         .order('created_at', { ascending: false }),
     ]).then(([companiesRes, sessionsRes]) => {
       if (companiesRes.error) {
@@ -48,6 +48,8 @@ export function CompanyHistory({ onSelect, onLoadSession }: CompanyHistoryProps)
             id: row.id as string,
             companyName: row.company_name as string,
             companyProfileId: (row.company_profile_id as string | null) ?? null,
+            companyRoleId: (row.company_role_id as string | null) ?? null,
+            roleTitle: null,
             interviewStyle: (row.interview_style as string | null) ?? null,
             createdAt: row.created_at as string,
             resumeId: (row.resume_id as string | null) ?? null,

--- a/apps/web/src/components/interview/InterviewSidebar.module.css
+++ b/apps/web/src/components/interview/InterviewSidebar.module.css
@@ -38,6 +38,14 @@
   gap: var(--space-2);
 }
 
+.roleTitle {
+  font-size: var(--font-xs);
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .styleBadge {
   font-size: var(--font-xs);
   padding: var(--space-1) var(--space-2);
@@ -45,6 +53,24 @@
   background-color: var(--color-bg-subtle);
   color: var(--color-text-secondary);
   text-transform: capitalize;
+}
+
+.researchLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: var(--font-xs);
+  color: var(--color-primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-full);
+  transition: background-color 0.15s;
+}
+
+.researchLink:hover {
+  background: var(--color-primary-subtle);
 }
 
 .accordions {

--- a/apps/web/src/components/interview/InterviewSidebar.tsx
+++ b/apps/web/src/components/interview/InterviewSidebar.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import { ArrowLeft, ChevronDown, ChevronRight, FileText, Maximize, X } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import { ArrowLeft, ChevronDown, ChevronRight, FileText, Maximize, X, BookOpen } from 'lucide-react'
 import { CompanyLogo } from './CompanyLogo'
 import { QuestionList } from './QuestionList'
 import { JobDescriptionForm } from './JobDescriptionForm'
@@ -26,6 +27,8 @@ interface InterviewSidebarProps {
   resume?: ResumeSummary | null
   cooldownEnd: number | null
   onCooldownStart: (end: number) => void
+  companyRoleId?: string | null
+  roleTitle?: string | null
 }
 
 function formatResumeText(parsed: StructuredResumeData | null | undefined): string {
@@ -67,11 +70,14 @@ export function InterviewSidebar({
   resume,
   cooldownEnd,
   onCooldownStart,
+  companyRoleId,
+  roleTitle,
 }: InterviewSidebarProps): React.JSX.Element {
+  const navigate = useNavigate()
   const [questionsOpen, setQuestionsOpen] = useState(true)
   const [jdOpen, setJdOpen] = useState(false)
-  const [resumeOpen, setResumeOpen] = useState(false) 
-  const [zoomedResume, setZoomedResume] = useState<ResumeSummary | null>(null) 
+  const [resumeOpen, setResumeOpen] = useState(false)
+  const [zoomedResume, setZoomedResume] = useState<ResumeSummary | null>(null)
 
   const logoProfile: CompanyProfile = companyProfile ?? {
     id: '',
@@ -81,14 +87,30 @@ export function InterviewSidebar({
     companySize: null,
   }
 
+  function handleViewResearch() {
+    navigate('/research', {
+      state: {
+        companyProfileId: selectedCompanyId,
+        roleId: companyRoleId,
+      },
+    })
+  }
+
   return (
     <div className={styles.sidebar}>
       <div className={styles.contextHeader}>
         <CompanyLogo company={logoProfile} size="md" />
         <div className={styles.contextInfo}>
           <span className={styles.companyName}>{companyName}</span>
+          {roleTitle && <span className={styles.roleTitle}>{roleTitle}</span>}
           <div className={styles.contextMeta}>
             <span className={styles.styleBadge}>{style}</span>
+            {selectedCompanyId && (
+              <button className={styles.researchLink} onClick={handleViewResearch}>
+                <BookOpen size={12} />
+                Research
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/apps/web/src/components/interview/SetupForm.tsx
+++ b/apps/web/src/components/interview/SetupForm.tsx
@@ -77,7 +77,7 @@ export function SetupForm({
   useEffect(() => {
     supabase
       .from('interview_sessions')
-      .select('id, company_name, company_profile_id, interview_style, created_at, resume_id')
+      .select('id, company_name, company_profile_id, company_role_id, interview_style, created_at, resume_id')
       .order('created_at', { ascending: false })
       .limit(10)
       .then(({ data, error }) => {
@@ -90,6 +90,8 @@ export function SetupForm({
             id: row.id as string,
             companyName: row.company_name as string,
             companyProfileId: (row.company_profile_id as string | null) ?? null,
+            companyRoleId: (row.company_role_id as string | null) ?? null,
+            roleTitle: null,
             interviewStyle: (row.interview_style as string | null) ?? null,
             createdAt: row.created_at as string,
             resumeId: (row.resume_id as string | null) ?? null,

--- a/apps/web/src/hooks/useCompanyRoles.ts
+++ b/apps/web/src/hooks/useCompanyRoles.ts
@@ -1,0 +1,130 @@
+import { useState, useEffect, useCallback } from 'react'
+import { supabase } from '@/lib/supabase'
+import { useAuth } from '@/contexts/AuthContext'
+import type { CompanyRole } from '@/types'
+
+export function useCompanyRoles(companyProfileId: string | null) {
+  const { user } = useAuth()
+  const [roles, setRoles] = useState<CompanyRole[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+
+  const fetchRoles = useCallback(async () => {
+    if (!user || !companyProfileId) {
+      setRoles([])
+      return
+    }
+
+    setIsLoading(true)
+    const { data, error } = await supabase
+      .from('company_roles')
+      .select('id, company_profile_id, role_title, job_description, is_active, created_at')
+      .eq('user_id', user.id)
+      .eq('company_profile_id', companyProfileId)
+      .order('created_at', { ascending: false })
+
+    if (error) {
+      console.error('Failed to fetch company roles:', error)
+    } else {
+      setRoles(
+        (data ?? []).map((r) => ({
+          id: r.id as string,
+          companyProfileId: r.company_profile_id as string,
+          roleTitle: r.role_title as string,
+          jobDescription: r.job_description as string | null,
+          isActive: r.is_active as boolean,
+          createdAt: r.created_at as string,
+        }))
+      )
+    }
+    setIsLoading(false)
+  }, [user, companyProfileId])
+
+  useEffect(() => {
+    fetchRoles()
+  }, [fetchRoles])
+
+  const addRole = useCallback(
+    async (title: string, jobDescription?: string): Promise<CompanyRole | null> => {
+      if (!user || !companyProfileId) return null
+
+      const { data, error } = await supabase
+        .from('company_roles')
+        .insert({
+          user_id: user.id,
+          company_profile_id: companyProfileId,
+          role_title: title.trim(),
+          job_description: jobDescription?.trim() || null,
+        })
+        .select('id, company_profile_id, role_title, job_description, is_active, created_at')
+        .single()
+
+      if (error) {
+        console.error('Failed to add company role:', error)
+        return null
+      }
+
+      const newRole: CompanyRole = {
+        id: data.id as string,
+        companyProfileId: data.company_profile_id as string,
+        roleTitle: data.role_title as string,
+        jobDescription: data.job_description as string | null,
+        isActive: data.is_active as boolean,
+        createdAt: data.created_at as string,
+      }
+      setRoles((prev) => [newRole, ...prev])
+      return newRole
+    },
+    [user, companyProfileId]
+  )
+
+  const updateRole = useCallback(
+    async (id: string, updates: Partial<Pick<CompanyRole, 'roleTitle' | 'jobDescription'>>) => {
+      const dbUpdates: Record<string, unknown> = {}
+      if (updates.roleTitle !== undefined) dbUpdates.role_title = updates.roleTitle.trim()
+      if (updates.jobDescription !== undefined)
+        dbUpdates.job_description = updates.jobDescription?.trim() || null
+
+      const { error } = await supabase.from('company_roles').update(dbUpdates).eq('id', id)
+
+      if (error) {
+        console.error('Failed to update company role:', error)
+        return
+      }
+
+      setRoles((prev) =>
+        prev.map((r) =>
+          r.id === id
+            ? {
+                ...r,
+                ...(updates.roleTitle !== undefined && { roleTitle: updates.roleTitle.trim() }),
+                ...(updates.jobDescription !== undefined && {
+                  jobDescription: updates.jobDescription?.trim() || null,
+                }),
+              }
+            : r
+        )
+      )
+    },
+    []
+  )
+
+  const deleteRole = useCallback(async (id: string) => {
+    const { error } = await supabase.from('company_roles').delete().eq('id', id)
+
+    if (error) {
+      console.error('Failed to delete company role:', error)
+      return
+    }
+
+    setRoles((prev) => prev.filter((r) => r.id !== id))
+  }, [])
+
+  return {
+    roles,
+    isLoading,
+    addRole,
+    updateRole,
+    deleteRole,
+    refreshRoles: fetchRoles,
+  }
+}

--- a/apps/web/src/hooks/useInterviewChat.ts
+++ b/apps/web/src/hooks/useInterviewChat.ts
@@ -187,6 +187,7 @@ export function useInterviewChat(
   style: InterviewStyle,
   activeResume?: ResumeSummary | null,
   onXpAwarded?: (xp: number, eventType: string) => void,
+  companyRoleId?: string | null,
 ): UseInterviewChatReturn {
   const { user } = useAuth()
   // Tracks whether a practice_sessions row has been recorded for this session.
@@ -266,6 +267,7 @@ export function useInterviewChat(
           .insert({
             user_id: user.id,
             company_profile_id: companyProfileId,
+            company_role_id: companyRoleId || null,
             company_name: jobData.companyName.trim(),
             job_description: jobData.jobDescription,
             interview_style: style,
@@ -379,7 +381,7 @@ export function useInterviewChat(
         setIsTyping(false)
       }
     },
-    [jobData, style, user, activeResume, onXpAwarded]
+    [jobData, style, user, activeResume, onXpAwarded, companyRoleId]
   )
 
   return { messages, isTyping, sendMessage, interviewSessionId, resumeSession, resetSession }

--- a/apps/web/src/hooks/useResearchChat.ts
+++ b/apps/web/src/hooks/useResearchChat.ts
@@ -1,5 +1,6 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
+import { supabase } from '@/lib/supabase'
 import type { Message } from '@/types'
 
 const RATE_LIMIT_FRIENDLY_MESSAGE =
@@ -57,16 +58,103 @@ function msg(role: Message['role'], content: string, id = `${role}-${Date.now()}
 export function useResearchChat({
   companies,
   jobDescription,
+  companyProfileId,
+  roleId,
 }: {
   companies: string[]
   jobDescription?: string
+  companyProfileId?: string | null
+  roleId?: string | null
 }) {
-  const { session } = useAuth()
+  const { session, user } = useAuth()
   const [messages, setMessages] = useState<Message[]>([INITIAL_MESSAGE])
   const [isStreaming, setIsStreaming] = useState(false)
+  const [sessionId, setSessionId] = useState<string | null>(null)
+  const sessionIdRef = useRef<string | null>(null)
+  const loadedRoleRef = useRef<string | null>(null)
+
+  // Load existing research session for this role
+  useEffect(() => {
+    if (!user || !roleId || loadedRoleRef.current === roleId) return
+    loadedRoleRef.current = roleId
+
+    supabase
+      .from('research_sessions')
+      .select('id, messages')
+      .eq('user_id', user.id)
+      .eq('company_role_id', roleId)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .then(({ data, error }) => {
+        if (error || !data || data.length === 0) return
+        const row = data[0]
+        const saved = row.messages as Array<{ role: string; content: string; timestamp: string }>
+        if (!saved || saved.length === 0) return
+
+        sessionIdRef.current = row.id as string
+        setSessionId(row.id as string)
+        setMessages(
+          saved.map((m, i) => ({
+            id: `saved-${i}`,
+            role: m.role as 'user' | 'assistant',
+            content: m.content,
+            timestamp: new Date(m.timestamp),
+          }))
+        )
+      })
+  }, [user, roleId])
+
+  // Persist messages to research_sessions after streaming completes
+  const persistMessages = useCallback(
+    async (allMessages: Message[]) => {
+      if (!user) return
+      // Only persist if we have a role context
+      if (!roleId) return
+
+      const rows = allMessages
+        .filter((m) => m.id !== 'init')
+        .map((m) => ({
+          role: m.role,
+          content: m.content,
+          timestamp: m.timestamp.toISOString(),
+        }))
+
+      if (rows.length === 0) return
+
+      if (sessionIdRef.current) {
+        // Update existing session
+        await supabase
+          .from('research_sessions')
+          .update({ messages: rows })
+          .eq('id', sessionIdRef.current)
+      } else {
+        // Create new session
+        const { data, error } = await supabase
+          .from('research_sessions')
+          .insert({
+            user_id: user.id,
+            company_profile_id: companyProfileId || null,
+            company_role_id: roleId,
+            title: rows[0]?.content?.slice(0, 80) || 'Research session',
+            messages: rows,
+          })
+          .select('id')
+          .single()
+
+        if (!error && data) {
+          sessionIdRef.current = data.id as string
+          setSessionId(data.id as string)
+        }
+      }
+    },
+    [user, companyProfileId, roleId]
+  )
 
   const resetMessages = useCallback(() => {
     setMessages([{ ...INITIAL_MESSAGE, timestamp: new Date() }])
+    sessionIdRef.current = null
+    setSessionId(null)
+    loadedRoleRef.current = null
   }, [])
 
   const sendMessage = useCallback(
@@ -154,6 +242,12 @@ export function useResearchChat({
           }
         }
         reader.releaseLock()
+
+        // Persist after streaming completes
+        setMessages((prev) => {
+          persistMessages(prev)
+          return prev
+        })
       } catch {
         setPlaceholderContent(
           "Couldn't reach the research service right now. Please check your connection and try again.",
@@ -162,8 +256,8 @@ export function useResearchChat({
         setIsStreaming(false)
       }
     },
-    [session?.access_token, companies, jobDescription, messages],
+    [session?.access_token, companies, jobDescription, messages, persistMessages],
   )
 
-  return { messages, isStreaming, sendMessage, resetMessages }
+  return { messages, isStreaming, sendMessage, resetMessages, sessionId }
 }

--- a/apps/web/src/pages/InterviewPage.tsx
+++ b/apps/web/src/pages/InterviewPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
+import { useLocation } from 'react-router-dom'
 import { SetupForm } from '@/components/interview/SetupForm'
 import { InterviewSidebar } from '@/components/interview/InterviewSidebar'
 import { ChatBox } from '@/components/interview/ChatBox'
@@ -47,11 +48,27 @@ function getInitialState() {
 }
 
 export default function InterviewPage(): JSX.Element {
+  const location = useLocation()
+  const roleState = location.state as {
+    companyName?: string
+    companyProfileId?: string
+    roleId?: string
+    roleTitle?: string
+    jobDescription?: string
+  } | null
+
   const initialState = useRef(getInitialState())
   const [phase, setPhase] = useState<Phase>(initialState.current ? 'interview' : 'setup')
-  const [jobDescription, setJobDescription] = useState(initialState.current?.jobDescription ?? '')
-  const [companyName, setCompanyName] = useState(initialState.current?.companyName ?? '')
-  const [selectedCompanyId, setSelectedCompanyId] = useState<string | null>(null)
+  const [jobDescription, setJobDescription] = useState(
+    roleState?.jobDescription || initialState.current?.jobDescription || ''
+  )
+  const [companyName, setCompanyName] = useState(
+    roleState?.companyName || initialState.current?.companyName || ''
+  )
+  const [selectedCompanyId, setSelectedCompanyId] = useState<string | null>(
+    roleState?.companyProfileId || null
+  )
+  const [companyRoleId, setCompanyRoleId] = useState<string | null>(roleState?.roleId || null)
   const [companyProfile, setCompanyProfile] = useState<CompanyProfile | null>(null)
   const [style, setStyle] = useState<InterviewStyle | null>(initialState.current?.style ?? 'mixed')
   const [selectedResumeId, setSelectedResumeId] = useState<string | null>(null)
@@ -97,6 +114,7 @@ export default function InterviewPage(): JSX.Element {
       style ?? 'mixed',
       activeResume,
       handleXpAwarded,
+      companyRoleId,
     )
 
   // Keep activeSessionId in sync and persist to sessionStorage
@@ -200,6 +218,7 @@ function handleStart(resumeObject?: ResumeSummary | null): void {
     setJobDescription('')
     setCompanyName('')
     setSelectedCompanyId(null)
+    setCompanyRoleId(null)
     setCompanyProfile(null)
     setStyle('mixed')
     setActiveResume(null)
@@ -353,6 +372,8 @@ function handleStart(resumeObject?: ResumeSummary | null): void {
         resume={activeResume}
         cooldownEnd={questionCooldownEnd}
         onCooldownStart={handleCooldownStart}
+        companyRoleId={companyRoleId}
+        roleTitle={roleState?.roleTitle || null}
       />
       <div className={styles.resizeHandle} onMouseDown={handleMouseDown} />
       <div className={styles.chatPanel}>

--- a/apps/web/src/pages/ResearchPage.module.css
+++ b/apps/web/src/pages/ResearchPage.module.css
@@ -276,6 +276,240 @@
   background: var(--color-bg-muted);
   color: #dc2626;
 }
+
+/* Expand button */
+
+.expandBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-tertiary);
+  padding: 0;
+  flex-shrink: 0;
+  transition: color 0.15s;
+}
+
+.expandBtn:hover {
+  color: var(--color-text);
+}
+
+/* ── Role list ──────────────────────────────────────────────────────────── */
+
+.roleList {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0 0 var(--space-2) var(--space-6);
+  margin-top: -2px;
+}
+
+.roleItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.375rem 0.5rem;
+  border-radius: var(--radius-md);
+  transition: background-color 0.15s;
+}
+
+.roleItem:hover {
+  background: var(--color-bg-muted);
+}
+
+.roleItemActive {
+  background: var(--color-primary-subtle);
+}
+
+.roleSelectBtn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text);
+  font-size: var(--font-xs);
+  font-weight: 500;
+  padding: 0;
+  min-width: 0;
+  flex: 1;
+}
+
+.roleName {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.roleActions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.15s;
+  flex-shrink: 0;
+}
+
+.roleItem:hover .roleActions {
+  opacity: 1;
+}
+
+.roleInterviewBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-primary);
+  padding: 0;
+  transition: background-color 0.15s;
+}
+
+.roleInterviewBtn:hover {
+  background: var(--color-primary-subtle);
+}
+
+.roleDeleteBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-tertiary);
+  padding: 0;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.roleDeleteBtn:hover {
+  background: var(--color-bg-muted);
+  color: #dc2626;
+}
+
+.roleEmpty {
+  font-size: var(--font-xs);
+  color: var(--color-text-tertiary);
+  padding: var(--space-1) 0;
+}
+
+/* Add role inline form */
+
+.addRoleBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: var(--font-xs);
+  font-weight: 500;
+  color: var(--color-primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.375rem 0.5rem;
+  border-radius: var(--radius-md);
+  transition: background-color 0.15s;
+}
+
+.addRoleBtn:hover {
+  background: var(--color-primary-subtle);
+}
+
+.addRoleForm {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+}
+
+.addRoleInput {
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  font-size: var(--font-xs);
+  font-family: inherit;
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.addRoleInput:focus {
+  border-color: var(--color-primary);
+}
+
+.addRoleJdInput {
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  font-size: var(--font-xs);
+  font-family: inherit;
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+  resize: vertical;
+  transition: border-color 0.15s;
+}
+
+.addRoleJdInput:focus {
+  border-color: var(--color-primary);
+}
+
+.addRoleFormActions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.addRoleSaveBtn {
+  font-size: var(--font-xs);
+  font-weight: 500;
+  color: #fff;
+  background: var(--color-primary);
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 0.25rem 0.625rem;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.addRoleSaveBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.addRoleSaveBtn:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.addRoleCancelBtn {
+  font-size: var(--font-xs);
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0.25rem 0.625rem;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.addRoleCancelBtn:hover {
+  background: var(--color-bg-muted);
+}
+
 .noResults {
   font-size: var(--font-sm);
   color: var(--color-text-tertiary);

--- a/apps/web/src/pages/ResearchPage.tsx
+++ b/apps/web/src/pages/ResearchPage.tsx
@@ -1,14 +1,15 @@
 import { useState, useRef, useEffect } from 'react'
-import { Plus, Search, Send, GripVertical, X, Paperclip, Star, Trash2 } from 'lucide-react'
+import { Plus, Search, Send, X, Paperclip, Star, Trash2, ChevronRight, ChevronDown, Play, Briefcase } from 'lucide-react'
 import { useNavigate, useLocation } from 'react-router-dom'
-import { Button } from '@/components/ui'
 import { useAuth } from '@/contexts/AuthContext'
 import { useResearchChat } from '@/hooks/useResearchChat'
 import { useResearchCompanies } from '@/hooks/useResearchCompanies'
-import { StandardToast } from '@/components/interview/Toast' 
+import { useCompanyRoles } from '@/hooks/useCompanyRoles'
+import { StandardToast } from '@/components/interview/Toast'
 import AddCompanyModal from './AddCompanyPage'
 import { cn } from '@/utils/cn'
-import { ConfirmModal } from '@/utils/ConfirmModal' 
+import { ConfirmModal } from '@/utils/ConfirmModal'
+import type { CompanyRole } from '@/types'
 import styles from './ResearchPage.module.css'
 
 interface CompanyProfile {
@@ -19,6 +20,10 @@ interface CompanyProfile {
   company_website?: string
 }
 
+interface ActiveContextItem {
+  company: CompanyProfile
+  role?: CompanyRole
+}
 
 const CATEGORY_STYLE: Record<string, string> = {
   Technology: styles.categoryTechnology,
@@ -40,8 +45,8 @@ function CompanyLogo({ company, styles }: { company: CompanyProfile, styles: Rec
     );
   }
   return (
-    <img 
-      src={`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/company-logo?domain=${encodeURIComponent(company.company_website)}`} 
+    <img
+      src={`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/company-logo?domain=${encodeURIComponent(company.company_website)}`}
       alt={`${company.name} logo`}
       className={styles.logoImage}
       onError={() => setHasError(true)}
@@ -55,7 +60,7 @@ export default function ResearchPage() {
   const [searchQuery, setSearchQuery] = useState(() => {
     return location.state?.companyName || '';
   });
-  const [activeContext, setActiveContext] = useState<CompanyProfile[]>([])
+  const [activeContext, setActiveContext] = useState<ActiveContextItem[]>([])
   const [input, setInput] = useState('')
   const [isDragOver, setIsDragOver] = useState(false)
   const [isAddModalOpen, setIsAddModalOpen] = useState(false)
@@ -65,6 +70,34 @@ export default function ResearchPage() {
   const [toastConfig, setToastConfig] = useState<{ message: string; variant: 'success' | 'error' } | null>(null)
   const [companyToDelete, setCompanyToDelete] = useState<{ id: string, name: string } | null>(null)
 
+  // Expandable roles state
+  const [expandedCompanyId, setExpandedCompanyId] = useState<string | null>(
+    (location.state as { companyProfileId?: string } | null)?.companyProfileId || null
+  )
+  const { roles, isLoading: rolesLoading, addRole, deleteRole } = useCompanyRoles(expandedCompanyId)
+
+  // Add role inline form state
+  const [isAddingRole, setIsAddingRole] = useState(false)
+  const [newRoleTitle, setNewRoleTitle] = useState('')
+  const [newRoleJd, setNewRoleJd] = useState('')
+  const roleInputRef = useRef<HTMLInputElement>(null)
+
+  // Auto-expand and select role from location state (e.g., coming back from interview)
+  const appliedLocationState = useRef(false)
+  useEffect(() => {
+    if (appliedLocationState.current) return
+    const state = location.state as { companyProfileId?: string; roleId?: string } | null
+    if (state?.roleId && roles.length > 0) {
+      appliedLocationState.current = true
+      const role = roles.find((r) => r.id === state.roleId)
+      if (role && dbCompanies.length > 0) {
+        const company = dbCompanies.find((c) => c.id === state.companyProfileId)
+        if (company && !activeContext.find((ctx) => ctx.role?.id === role.id)) {
+          setActiveContext((prev) => [...prev, { company, role }])
+        }
+      }
+    }
+  }, [location.state, roles, dbCompanies, activeContext])
 
   useEffect(() => {
     if (location.state?.newCompanyId && dbCompanies.length > 0) {
@@ -79,23 +112,25 @@ export default function ResearchPage() {
   }, [location.state, dbCompanies, navigate, location.pathname, searchQuery])
   const userInitial = user?.email?.[0].toUpperCase() ?? '?'
 
-  const companyNames = activeContext.map((c) => c.name)
-  const { messages, isStreaming, sendMessage, resetMessages } = useResearchChat({
+  // Derive active context for the chat hook
+  const activeRole = activeContext.length === 1 ? activeContext[0].role : undefined
+  const activeCompanyProfileId = activeContext.length === 1 ? activeContext[0].company.id : undefined
+  const companyNames = activeContext.map((ctx) => ctx.company.name)
+  const { messages, isStreaming, sendMessage } = useResearchChat({
     companies: companyNames,
-    jobDescription: undefined,
+    jobDescription: activeRole?.jobDescription || undefined,
+    companyProfileId: activeCompanyProfileId || null,
+    roleId: activeRole?.id || null,
   })
 
   const filteredCompanies = dbCompanies
     .filter((c) => c.name.toLowerCase().includes(searchQuery.toLowerCase()))
     .sort((a, b) => Number(b.isFavorite) - Number(a.isFavorite))
+
   const handleToggleFavorite = (id: string) => {
     toggleFavorite(id)
   }
-  // function toggleFavorite(id: string) {
-  //   setCompanies((prev) =>
-  //     prev.map((c) => (c.id === id ? { ...c, isFavorite: !c.isFavorite } : c)),
-  //   )
-  // }
+
   const handleDeleteCompany = async () => {
     if (!companyToDelete) return;
     const { id, name } = companyToDelete;
@@ -119,8 +154,8 @@ export default function ResearchPage() {
     setIsDragOver(false)
     const company = draggingCompany.current
     if (!company) return
-    if (!activeContext.find((c) => c.id === company.id)) {
-      setActiveContext((prev) => [...prev, company])
+    if (!activeContext.find((ctx) => ctx.company.id === company.id && !ctx.role)) {
+      setActiveContext((prev) => [...prev, { company }])
     }
     draggingCompany.current = null
   }
@@ -136,14 +171,10 @@ export default function ResearchPage() {
     }
   }
 
-  function removeFromContext(id: string) {
-    setActiveContext((prev) => prev.filter((c) => c.id !== id))
-  }
-
-  function handleNewBoard() {
-    setActiveContext([])
-    resetMessages()
-    setInput('')
+  function removeFromContext(companyId: string, roleId?: string) {
+    setActiveContext((prev) =>
+      prev.filter((ctx) => !(ctx.company.id === companyId && ctx.role?.id === roleId))
+    )
   }
 
   function handleSend() {
@@ -160,6 +191,51 @@ export default function ResearchPage() {
     }
   }
 
+  function handleToggleExpand(companyId: string) {
+    setExpandedCompanyId((prev) => (prev === companyId ? null : companyId))
+    setIsAddingRole(false)
+    setNewRoleTitle('')
+    setNewRoleJd('')
+  }
+
+  function handleSelectRole(company: CompanyProfile, role: CompanyRole) {
+    // Add role to context if not already there
+    if (!activeContext.find((ctx) => ctx.role?.id === role.id)) {
+      setActiveContext((prev) => [...prev, { company, role }])
+    }
+  }
+
+  function handleStartInterview(company: CompanyProfile, role: CompanyRole) {
+    navigate('/interview', {
+      state: {
+        companyName: company.name,
+        companyProfileId: company.id,
+        roleId: role.id,
+        roleTitle: role.roleTitle,
+        jobDescription: role.jobDescription || '',
+      },
+    })
+  }
+
+  async function handleAddRole() {
+    const title = newRoleTitle.trim()
+    if (!title) return
+    const result = await addRole(title, newRoleJd || undefined)
+    if (result) {
+      setToastConfig({ message: `Added role "${title}"`, variant: 'success' })
+    }
+    setNewRoleTitle('')
+    setNewRoleJd('')
+    setIsAddingRole(false)
+  }
+
+  async function handleDeleteRole(roleId: string, roleTitle: string) {
+    await deleteRole(roleId)
+    // Remove from active context if present
+    setActiveContext((prev) => prev.filter((ctx) => ctx.role?.id !== roleId))
+    setToastConfig({ message: `Removed role "${roleTitle}"`, variant: 'error' })
+  }
+
   return (
     <div className={styles.page}>
       <div className={styles.header}>
@@ -169,10 +245,6 @@ export default function ResearchPage() {
             Chat with AI to analyze companies, compare roles, and build your knowledge base
           </p>
         </div>
-        <Button variant="primary" size="sm" onClick={handleNewBoard}>
-          <Plus size={14} />
-          New Board
-        </Button>
       </div>
 
       <div className={styles.layout}>
@@ -188,49 +260,143 @@ export default function ResearchPage() {
             />
           </div>
 
-          <p className={styles.sidebarLabel}>Saved Profiles (Drag to Chat)</p>
+          <p className={styles.sidebarLabel}>Saved Profiles</p>
 
           <div className={styles.companyList}>
             {filteredCompanies.map((company) => (
-              <div
-                key={company.id}
-                className={styles.companyCard}
-                draggable
-                onDragStart={() => handleDragStart(company)}
-              >
-                <GripVertical size={14} className={styles.dragHandle} />
-                <CompanyLogo company={company} styles={styles} />
-                <div className={styles.companyInfo}>
-                  <span className={styles.companyName}>{company.name}</span>
-                  <span
-                    className={cn(
-                      styles.categoryBadge,
-                      CATEGORY_STYLE[company.category] ?? styles.categoryDefault,
-                    )}
+              <div key={company.id}>
+                <div
+                  className={styles.companyCard}
+                  draggable
+                  onDragStart={() => handleDragStart(company)}
+                >
+                  <button
+                    className={styles.expandBtn}
+                    onClick={(e) => { e.stopPropagation(); handleToggleExpand(company.id) }}
+                    aria-label={expandedCompanyId === company.id ? 'Collapse' : 'Expand'}
                   >
-                    {company.category}
-                  </span>
+                    {expandedCompanyId === company.id ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                  </button>
+                  <CompanyLogo company={company} styles={styles} />
+                  <div className={styles.companyInfo}>
+                    <span className={styles.companyName}>{company.name}</span>
+                    <span
+                      className={cn(
+                        styles.categoryBadge,
+                        CATEGORY_STYLE[company.category] ?? styles.categoryDefault,
+                      )}
+                    >
+                      {company.category}
+                    </span>
+                  </div>
+                  <button
+                    className={cn(styles.starBtn, company.isFavorite && styles.starBtnActive)}
+                    onClick={(e) => { e.stopPropagation(); handleToggleFavorite(company.id) }}
+                    aria-label={company.isFavorite ? 'Unfavorite' : 'Favorite'}
+                  >
+                    <Star size={13} />
+                  </button>
+                  <button
+                    className={styles.deleteBtn}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setCompanyToDelete({ id: company.id, name: company.name });
+                    }}
+                    aria-label={`Delete ${company.name}`}
+                  >
+                    <Trash2 size={13} />
+                  </button>
                 </div>
-                <button
-                  className={cn(styles.starBtn, company.isFavorite && styles.starBtnActive)}
-                  onClick={(e) => { e.stopPropagation(); handleToggleFavorite(company.id) }}
-                  aria-label={company.isFavorite ? 'Unfavorite' : 'Favorite'}
-                >
-                  <Star size={13} />
-                </button>
-                <button
-                  className={styles.deleteBtn}
-                  onClick={(e) => {
-                    e.stopPropagation(); 
-                    setCompanyToDelete({ id: company.id, name: company.name });
-                  }}
-                  aria-label={`Delete ${company.name}`}
-                >
-                  <Trash2 size={13} />
-                </button>
+
+                {/* Expandable roles list */}
+                {expandedCompanyId === company.id && (
+                  <div className={styles.roleList}>
+                    {rolesLoading && roles.length === 0 && (
+                      <p className={styles.roleEmpty}>Loading roles...</p>
+                    )}
+                    {!rolesLoading && roles.length === 0 && !isAddingRole && (
+                      <p className={styles.roleEmpty}>No roles yet</p>
+                    )}
+                    {roles.map((role) => (
+                      <div
+                        key={role.id}
+                        className={cn(
+                          styles.roleItem,
+                          activeContext.find((ctx) => ctx.role?.id === role.id) && styles.roleItemActive,
+                        )}
+                      >
+                        <button
+                          className={styles.roleSelectBtn}
+                          onClick={() => handleSelectRole(company, role)}
+                          title="Add to research context"
+                        >
+                          <Briefcase size={11} />
+                          <span className={styles.roleName}>{role.roleTitle}</span>
+                        </button>
+                        <div className={styles.roleActions}>
+                          <button
+                            className={styles.roleInterviewBtn}
+                            onClick={() => handleStartInterview(company, role)}
+                            title="Start interview"
+                          >
+                            <Play size={11} />
+                          </button>
+                          <button
+                            className={styles.roleDeleteBtn}
+                            onClick={() => handleDeleteRole(role.id, role.roleTitle)}
+                            title="Delete role"
+                          >
+                            <Trash2 size={11} />
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+
+                    {/* Inline add role form */}
+                    {isAddingRole ? (
+                      <div className={styles.addRoleForm}>
+                        <input
+                          ref={roleInputRef}
+                          className={styles.addRoleInput}
+                          placeholder="Role title (e.g. SWE Intern)"
+                          value={newRoleTitle}
+                          onChange={(e) => setNewRoleTitle(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') handleAddRole()
+                            if (e.key === 'Escape') { setIsAddingRole(false); setNewRoleTitle(''); setNewRoleJd('') }
+                          }}
+                          autoFocus
+                        />
+                        <textarea
+                          className={styles.addRoleJdInput}
+                          placeholder="Job description (optional)"
+                          value={newRoleJd}
+                          onChange={(e) => setNewRoleJd(e.target.value)}
+                          rows={2}
+                        />
+                        <div className={styles.addRoleFormActions}>
+                          <button className={styles.addRoleSaveBtn} onClick={handleAddRole} disabled={!newRoleTitle.trim()}>
+                            Add
+                          </button>
+                          <button className={styles.addRoleCancelBtn} onClick={() => { setIsAddingRole(false); setNewRoleTitle(''); setNewRoleJd('') }}>
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <button
+                        className={styles.addRoleBtn}
+                        onClick={() => { setIsAddingRole(true); setTimeout(() => roleInputRef.current?.focus(), 0) }}
+                      >
+                        <Plus size={11} />
+                        Add Role
+                      </button>
+                    )}
+                  </div>
+                )}
               </div>
             ))}
-            
+
             {isLoading && filteredCompanies.length === 0 && (
               <p className={styles.noResults}>Loading companies...</p>
             )}
@@ -265,13 +431,13 @@ export default function ResearchPage() {
           >
             <span className={styles.contextLabel}>Active Context:</span>
             <div className={styles.contextChips}>
-              {activeContext.map((company) => (
-                <span key={company.id} className={styles.chip}>
-                  {company.name}
+              {activeContext.map((ctx) => (
+                <span key={`${ctx.company.id}-${ctx.role?.id || 'no-role'}`} className={styles.chip}>
+                  {ctx.role ? `${ctx.company.name} \u2014 ${ctx.role.roleTitle}` : ctx.company.name}
                   <button
                     className={styles.chipRemove}
-                    onClick={() => removeFromContext(company.id)}
-                    aria-label={`Remove ${company.name} from context`}
+                    onClick={() => removeFromContext(ctx.company.id, ctx.role?.id)}
+                    aria-label={`Remove ${ctx.company.name} from context`}
                   >
                     <X size={10} />
                   </button>
@@ -340,8 +506,8 @@ export default function ResearchPage() {
         </div>
       </div>
 
-      <AddCompanyModal 
-        isOpen={isAddModalOpen} 
+      <AddCompanyModal
+        isOpen={isAddModalOpen}
         onClose={() => setIsAddModalOpen(false)}
         initialCompanyName={searchQuery}
         onSuccess={async (_newId, newName) => {
@@ -361,10 +527,10 @@ export default function ResearchPage() {
       />
       {/* Toast Component */}
       {toastConfig && (
-        <StandardToast 
-          message={toastConfig.message} 
-          variant={toastConfig.variant} 
-          onDone={() => setToastConfig(null)} 
+        <StandardToast
+          message={toastConfig.message}
+          variant={toastConfig.variant}
+          onDone={() => setToastConfig(null)}
         />
       )}
     </div>

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -42,10 +42,21 @@ export interface Message {
   timestamp: Date
 }
 
+export interface CompanyRole {
+  id: string
+  companyProfileId: string
+  roleTitle: string
+  jobDescription: string | null
+  isActive: boolean
+  createdAt: string
+}
+
 export interface InterviewSessionSummary {
   id: string
   companyName: string
   companyProfileId: string | null
+  companyRoleId: string | null
+  roleTitle: string | null
   interviewStyle: string | null
   createdAt: string
   resumeId?: string | null

--- a/docs/AGILE_PLANNING.md
+++ b/docs/AGILE_PLANNING.md
@@ -1,5 +1,5 @@
 # Agile Planning  
-
+ 
 ## Team Context
 
 Our team consists of working professionals. We operate async-first using Discord and GitHub Issues, with necessary meetings held on weekends.   

--- a/supabase/migrations/20260417000001_create_company_roles_table.sql
+++ b/supabase/migrations/20260417000001_create_company_roles_table.sql
@@ -1,0 +1,56 @@
+-- Company roles: track specific positions/roles per company
+CREATE TABLE company_roles (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  company_profile_id UUID NOT NULL REFERENCES company_profiles(id) ON DELETE CASCADE,
+  role_title TEXT NOT NULL,
+  job_description TEXT,
+  is_active BOOLEAN DEFAULT true NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Indexes
+CREATE INDEX company_roles_user_id_idx ON company_roles(user_id);
+CREATE INDEX company_roles_company_profile_id_idx ON company_roles(company_profile_id);
+
+-- Enable RLS
+ALTER TABLE company_roles ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+CREATE POLICY "Users can view own company roles"
+  ON company_roles FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own company roles"
+  ON company_roles FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own company roles"
+  ON company_roles FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own company roles"
+  ON company_roles FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- Auto-update updated_at
+CREATE TRIGGER company_roles_updated_at
+  BEFORE UPDATE ON company_roles
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();
+
+-- Add company_role_id FK to existing tables
+ALTER TABLE research_sessions
+  ADD COLUMN company_role_id UUID REFERENCES company_roles(id) ON DELETE SET NULL;
+
+ALTER TABLE interview_sessions
+  ADD COLUMN company_role_id UUID REFERENCES company_roles(id) ON DELETE SET NULL;
+
+ALTER TABLE interview_questions
+  ADD COLUMN company_role_id UUID REFERENCES company_roles(id) ON DELETE SET NULL;
+
+-- Indexes on new FK columns
+CREATE INDEX research_sessions_company_role_id_idx ON research_sessions(company_role_id);
+CREATE INDEX interview_sessions_company_role_id_idx ON interview_sessions(company_role_id);
+CREATE INDEX interview_questions_company_role_id_idx ON interview_questions(company_role_id);


### PR DESCRIPTION
## Problem

The Research Board and Interview Simulator are disconnected features. Users can research companies and practice interviews independently, but there is no way to:

- Track specific roles/positions under a company (e.g., "Google > SWE Intern, PM Intern")
- Launch an interview directly from the Research Board for a specific role
- Navigate back from an interview to the related research
- Persist research chat history (currently lost on page reload)

## Solution

### 1. Roles per company
- New `company_roles` table (`role_title`, `job_description`, linked to `company_profiles`)
- Expandable company cards in the Research Board sidebar showing roles underneath
- Inline form to add roles with title and optional job description
- Clicking a role adds it to the research chat context; chat persists per role

### 2. Research chat persistence
- Wire up the existing (unused) `research_sessions` table with a new `company_role_id` FK
- Load previous chat on role selection; auto-save after each AI response

### 3. Cross-linking
- **Research > Interview:** "Start Interview" button on each role navigates to `/interview` with company name, role, and JD pre-filled
- **Interview > Research:** "Research" link in the interview sidebar navigates back to `/research` with the relevant company/role expanded

## Files changed

- `supabase/migrations/20260417000001_create_company_roles_table.sql` (new)
- `apps/web/src/types/index.ts`
- `apps/web/src/hooks/useCompanyRoles.ts` (new)
- `apps/web/src/hooks/useResearchChat.ts`
- `apps/web/src/hooks/useInterviewChat.ts`
- `apps/web/src/pages/ResearchPage.tsx`
- `apps/web/src/pages/ResearchPage.module.css`
- `apps/web/src/pages/InterviewPage.tsx`
- `apps/web/src/components/interview/InterviewSidebar.tsx`
- `apps/web/src/components/interview/InterviewSidebar.module.css`
- `apps/web/src/components/interview/CompanyHistory.tsx`
- `apps/web/src/components/interview/SetupForm.tsx`