### PR TITLE
Wire up dashboard week and month date filters

### DIFF
--- a/apps/web/src/hooks/useDashboardData.ts
+++ b/apps/web/src/hooks/useDashboardData.ts
@@ -1,7 +1,14 @@
 import { useState, useEffect } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/contexts/AuthContext'
-import type { DashboardData, ResearchSessionSummary, CompanySummary, PipelineCounts } from '@/types'
+import type {
+  DashboardData,
+  ResearchSessionSummary,
+  CompanySummary,
+  PipelineCounts,
+  DashboardRange,
+  PracticeConsistencyData,
+} from '@/types'
 
 interface UseDashboardDataReturn {
   data: DashboardData | null
@@ -9,11 +16,21 @@ interface UseDashboardDataReturn {
   fetchError: string | null
 }
 
+interface UseDashboardDataParams {
+  practiceRange: DashboardRange
+  pipelineRange: DashboardRange
+}
+
 interface RawResearchSession {
   id: string
   title: string | null
   created_at: string
   company_profiles: { company_name: string; industry: string | null } | null
+}
+
+interface RawPracticeSession {
+  created_at: string
+  duration_minutes: number
 }
 
 type ApplicationStatus =
@@ -32,13 +49,97 @@ const KNOWN_STATUSES: readonly ApplicationStatus[] = [
   'rejected',
   'withdrawn',
 ]
+
 const INTERVIEW_STATUSES: readonly ApplicationStatus[] = ['phone_screen', 'interviewing']
 
 function isApplicationStatus(value: unknown): value is ApplicationStatus {
   return KNOWN_STATUSES.includes(value as ApplicationStatus)
 }
 
-export function useDashboardData(): UseDashboardDataReturn {
+function getStartOfIsoWeek(date: Date): Date {
+  const copy = new Date(date)
+  const day = copy.getDay()
+  const diff = day === 0 ? -6 : 1 - day
+  copy.setHours(0, 0, 0, 0)
+  copy.setDate(copy.getDate() + diff)
+  return copy
+}
+
+function getEndOfIsoWeek(date: Date): Date {
+  const start = getStartOfIsoWeek(date)
+  const end = new Date(start)
+  end.setDate(start.getDate() + 7)
+  return end
+}
+
+function getStartOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1)
+}
+
+function getEndOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 1)
+}
+
+function getRangeBounds(range: DashboardRange): { start: Date; end: Date } {
+  const now = new Date()
+
+  if (range === 'week') {
+    return {
+      start: getStartOfIsoWeek(now),
+      end: getEndOfIsoWeek(now),
+    }
+  }
+
+  return {
+    start: getStartOfMonth(now),
+    end: getEndOfMonth(now),
+  }
+}
+
+function buildPracticeBuckets(
+  rows: RawPracticeSession[],
+  range: DashboardRange,
+): PracticeConsistencyData {
+  if (range === 'week') {
+    const start = getStartOfIsoWeek(new Date())
+    const buckets = Array.from({ length: 7 }, () => 0)
+
+    for (const row of rows) {
+      const createdAt = new Date(row.created_at)
+      const diffDays = Math.floor(
+        (createdAt.getTime() - start.getTime()) / (1000 * 60 * 60 * 24),
+      )
+
+      if (diffDays >= 0 && diffDays < 7) {
+        buckets[diffDays] += row.duration_minutes
+      }
+    }
+
+    return {
+      totalMinutes: rows.reduce((sum, row) => sum + row.duration_minutes, 0),
+      buckets,
+    }
+  }
+
+  const buckets = Array.from({ length: 5 }, () => 0)
+
+  for (const row of rows) {
+    const createdAt = new Date(row.created_at)
+    const dayOfMonth = createdAt.getDate()
+    const weekIndex = Math.min(Math.floor((dayOfMonth - 1) / 7), 4)
+    buckets[weekIndex] += row.duration_minutes
+  }
+
+  return {
+    totalMinutes: rows.reduce((sum, row) => sum + row.duration_minutes, 0),
+    buckets,
+  }
+}
+
+export function useDashboardData({
+  practiceRange,
+  pipelineRange,
+}: UseDashboardDataParams): UseDashboardDataReturn {
   const { user, loading: isAuthLoading } = useAuth()
   const [data, setData] = useState<DashboardData | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -56,27 +157,46 @@ export function useDashboardData(): UseDashboardDataReturn {
 
     async function fetchDashboardData(): Promise<void> {
       try {
-        const [sessionsResult, companiesResult, applicationsResult] = await Promise.all([
-          supabase
-            .from('research_sessions')
-            .select('id, title, created_at, company_profiles(company_name, industry)')
-            .eq('user_id', userId)
-            .order('created_at', { ascending: false })
-            .limit(3),
-          supabase
-            .from('company_profiles')
-            .select('id, company_name, industry')
-            .eq('user_id', userId)
-            .order('created_at', { ascending: false })
-            .limit(4),
-          supabase.from('job_applications').select('status').eq('user_id', userId),
-        ])
+        setIsLoading(true)
+
+        const practiceBounds = getRangeBounds(practiceRange)
+        const pipelineBounds = getRangeBounds(pipelineRange)
+
+        const [sessionsResult, companiesResult, applicationsResult, practiceResult] =
+          await Promise.all([
+            supabase
+              .from('research_sessions')
+              .select('id, title, created_at, company_profiles(company_name, industry)')
+              .eq('user_id', userId)
+              .order('created_at', { ascending: false })
+              .limit(3),
+            supabase
+              .from('company_profiles')
+              .select('id, company_name, industry')
+              .eq('user_id', userId)
+              .order('created_at', { ascending: false })
+              .limit(4),
+            supabase
+              .from('job_applications')
+              .select('status')
+              .eq('user_id', userId)
+              .gte('created_at', pipelineBounds.start.toISOString())
+              .lt('created_at', pipelineBounds.end.toISOString()),
+            supabase
+              .from('practice_sessions')
+              .select('created_at, duration_minutes')
+              .eq('user_id', userId)
+              .gte('created_at', practiceBounds.start.toISOString())
+              .lt('created_at', practiceBounds.end.toISOString())
+              .order('created_at', { ascending: true }),
+          ])
 
         if (controller.signal.aborted) return
 
         if (sessionsResult.error) throw sessionsResult.error
         if (companiesResult.error) throw companiesResult.error
         if (applicationsResult.error) throw applicationsResult.error
+        if (practiceResult.error) throw practiceResult.error
 
         const rawSessions = (sessionsResult.data ?? []) as unknown as RawResearchSession[]
         const recentSessions: ResearchSessionSummary[] = rawSessions.map((row) => ({
@@ -96,14 +216,18 @@ export function useDashboardData(): UseDashboardDataReturn {
         const statuses = (applicationsResult.data ?? [])
           .map((row) => row.status)
           .filter(isApplicationStatus)
+
         const pipeline: PipelineCounts = {
           total: statuses.length,
           interviews: statuses.filter((s) => INTERVIEW_STATUSES.includes(s)).length,
           offers: statuses.filter((s) => s === 'offer').length,
         }
 
+        const practiceRows = (practiceResult.data ?? []) as RawPracticeSession[]
+        const practiceConsistency = buildPracticeBuckets(practiceRows, practiceRange)
+
         if (controller.signal.aborted) return
-        setData({ recentSessions, companies, pipeline })
+        setData({ recentSessions, companies, pipeline, practiceConsistency })
         setFetchError(null)
       } catch (err) {
         if (controller.signal.aborted) return
@@ -118,7 +242,7 @@ export function useDashboardData(): UseDashboardDataReturn {
     fetchDashboardData()
 
     return () => controller.abort()
-  }, [user, isAuthLoading])
+  }, [user, isAuthLoading, practiceRange, pipelineRange])
 
   return { data, isLoading, fetchError }
 }

--- a/apps/web/src/hooks/useDashboardData.ts
+++ b/apps/web/src/hooks/useDashboardData.ts
@@ -141,108 +141,238 @@ export function useDashboardData({
   pipelineRange,
 }: UseDashboardDataParams): UseDashboardDataReturn {
   const { user, loading: isAuthLoading } = useAuth()
-  const [data, setData] = useState<DashboardData | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
+  const [recentSessions, setRecentSessions] = useState<ResearchSessionSummary[] | null>(null)
+  const [companies, setCompanies] = useState<CompanySummary[] | null>(null)
+  const [pipeline, setPipeline] = useState<PipelineCounts | null>(null)
+  const [practiceConsistency, setPracticeConsistency] = useState<PracticeConsistencyData | null>(null)
+  
   const [fetchError, setFetchError] = useState<string | null>(null)
 
+  const isInitialLoad = !recentSessions || !companies || !pipeline || !practiceConsistency
+  const isLoading = isAuthLoading || (isInitialLoad && !fetchError)
+
   useEffect(() => {
-    if (isAuthLoading) return
+    // if (isAuthLoading) return
     if (!user) {
-      setIsLoading(false)
       return
     }
 
     const controller = new AbortController()
     const userId = user.id
 
-    async function fetchDashboardData(): Promise<void> {
+  //   async function fetchDashboardData(): Promise<void> {
+  //     try {
+  //       setIsLoading(true)
+
+  //       const practiceBounds = getRangeBounds(practiceRange)
+  //       const pipelineBounds = getRangeBounds(pipelineRange)
+
+  //       const [sessionsResult, companiesResult, applicationsResult, practiceResult] =
+  //         await Promise.all([
+  //           supabase
+  //             .from('research_sessions')
+  //             .select('id, title, created_at, company_profiles(company_name, industry)')
+  //             .eq('user_id', userId)
+  //             .order('created_at', { ascending: false })
+  //             .limit(3),
+  //           supabase
+  //             .from('company_profiles')
+  //             .select('id, company_name, industry')
+  //             .eq('user_id', userId)
+  //             .order('created_at', { ascending: false })
+  //             .limit(4),
+  //           supabase
+  //             .from('job_applications')
+  //             .select('status')
+  //             .eq('user_id', userId)
+  //             .gte('created_at', pipelineBounds.start.toISOString())
+  //             .lt('created_at', pipelineBounds.end.toISOString()),
+  //           supabase
+  //             .from('practice_sessions')
+  //             .select('created_at, duration_minutes')
+  //             .eq('user_id', userId)
+  //             .gte('created_at', practiceBounds.start.toISOString())
+  //             .lt('created_at', practiceBounds.end.toISOString())
+  //             .order('created_at', { ascending: true }),
+  //         ])
+
+  //       if (controller.signal.aborted) return
+
+  //       if (sessionsResult.error) throw sessionsResult.error
+  //       if (companiesResult.error) throw companiesResult.error
+  //       if (applicationsResult.error) throw applicationsResult.error
+  //       if (practiceResult.error) throw practiceResult.error
+
+  //       const rawSessions = (sessionsResult.data ?? []) as unknown as RawResearchSession[]
+  //       const recentSessions: ResearchSessionSummary[] = rawSessions.map((row) => ({
+  //         id: row.id,
+  //         title: row.title,
+  //         createdAt: row.created_at,
+  //         companyName: row.company_profiles?.company_name ?? null,
+  //         industry: row.company_profiles?.industry ?? null,
+  //       }))
+
+  //       const companies: CompanySummary[] = (companiesResult.data ?? []).map((row) => ({
+  //         id: row.id,
+  //         companyName: row.company_name,
+  //         industry: row.industry,
+  //       }))
+
+  //       const statuses = (applicationsResult.data ?? [])
+  //         .map((row) => row.status)
+  //         .filter(isApplicationStatus)
+
+  //       const pipeline: PipelineCounts = {
+  //         total: statuses.length,
+  //         interviews: statuses.filter((s) => INTERVIEW_STATUSES.includes(s)).length,
+  //         offers: statuses.filter((s) => s === 'offer').length,
+  //       }
+
+  //       const practiceRows = (practiceResult.data ?? []) as RawPracticeSession[]
+  //       const practiceConsistency = buildPracticeBuckets(practiceRows, practiceRange)
+
+  //       if (controller.signal.aborted) return
+  //       setData({ recentSessions, companies, pipeline, practiceConsistency })
+  //       setFetchError(null)
+  //     } catch (err) {
+  //       if (controller.signal.aborted) return
+  //       setFetchError(err instanceof Error ? err.message : 'Failed to load dashboard data')
+  //     } finally {
+  //       if (!controller.signal.aborted) {
+  //         setIsLoading(false)
+  //       }
+  //     }
+  //   }
+
+  //   fetchDashboardData()
+
+  //   return () => controller.abort()
+  // }, [user, isAuthLoading, practiceRange, pipelineRange])
+    async function fetchCoreData() {
       try {
-        setIsLoading(true)
+        const [sessionsRes, companiesRes] = await Promise.all([
+          supabase
+            .from('research_sessions')
+            .select('id, title, created_at, company_profiles(company_name, industry)')
+            .eq('user_id', userId)
+            .order('created_at', { ascending: false })
+            .limit(3)
+            .abortSignal(controller.signal),
+          supabase
+            .from('company_profiles')
+            .select('id, company_name, industry')
+            .eq('user_id', userId)
+            .order('created_at', { ascending: false })
+            .limit(4)
+            .abortSignal(controller.signal),
+        ])
 
-        const practiceBounds = getRangeBounds(practiceRange)
-        const pipelineBounds = getRangeBounds(pipelineRange)
+        if (sessionsRes.error) throw sessionsRes.error
+        if (companiesRes.error) throw companiesRes.error
 
-        const [sessionsResult, companiesResult, applicationsResult, practiceResult] =
-          await Promise.all([
-            supabase
-              .from('research_sessions')
-              .select('id, title, created_at, company_profiles(company_name, industry)')
-              .eq('user_id', userId)
-              .order('created_at', { ascending: false })
-              .limit(3),
-            supabase
-              .from('company_profiles')
-              .select('id, company_name, industry')
-              .eq('user_id', userId)
-              .order('created_at', { ascending: false })
-              .limit(4),
-            supabase
-              .from('job_applications')
-              .select('status')
-              .eq('user_id', userId)
-              .gte('created_at', pipelineBounds.start.toISOString())
-              .lt('created_at', pipelineBounds.end.toISOString()),
-            supabase
-              .from('practice_sessions')
-              .select('created_at, duration_minutes')
-              .eq('user_id', userId)
-              .gte('created_at', practiceBounds.start.toISOString())
-              .lt('created_at', practiceBounds.end.toISOString())
-              .order('created_at', { ascending: true }),
-          ])
-
-        if (controller.signal.aborted) return
-
-        if (sessionsResult.error) throw sessionsResult.error
-        if (companiesResult.error) throw companiesResult.error
-        if (applicationsResult.error) throw applicationsResult.error
-        if (practiceResult.error) throw practiceResult.error
-
-        const rawSessions = (sessionsResult.data ?? []) as unknown as RawResearchSession[]
-        const recentSessions: ResearchSessionSummary[] = rawSessions.map((row) => ({
+        const rawSessions = (sessionsRes.data ?? []) as unknown as RawResearchSession[]
+        setRecentSessions(rawSessions.map((row) => ({
           id: row.id,
           title: row.title,
           createdAt: row.created_at,
           companyName: row.company_profiles?.company_name ?? null,
           industry: row.company_profiles?.industry ?? null,
-        }))
+        })))
 
-        const companies: CompanySummary[] = (companiesResult.data ?? []).map((row) => ({
+        setCompanies((companiesRes.data ?? []).map((row) => ({
           id: row.id,
           companyName: row.company_name,
           industry: row.industry,
-        }))
-
-        const statuses = (applicationsResult.data ?? [])
-          .map((row) => row.status)
-          .filter(isApplicationStatus)
-
-        const pipeline: PipelineCounts = {
-          total: statuses.length,
-          interviews: statuses.filter((s) => INTERVIEW_STATUSES.includes(s)).length,
-          offers: statuses.filter((s) => s === 'offer').length,
-        }
-
-        const practiceRows = (practiceResult.data ?? []) as RawPracticeSession[]
-        const practiceConsistency = buildPracticeBuckets(practiceRows, practiceRange)
-
-        if (controller.signal.aborted) return
-        setData({ recentSessions, companies, pipeline, practiceConsistency })
-        setFetchError(null)
+        })))
       } catch (err) {
-        if (controller.signal.aborted) return
-        setFetchError(err instanceof Error ? err.message : 'Failed to load dashboard data')
-      } finally {
         if (!controller.signal.aborted) {
-          setIsLoading(false)
+          setFetchError(err instanceof Error ? err.message : 'Failed to load core data')
         }
       }
     }
 
-    fetchDashboardData()
-
+    fetchCoreData()
     return () => controller.abort()
-  }, [user, isAuthLoading, practiceRange, pipelineRange])
+  }, [user])
+  // EFFECT 2: Practice Consistency (Re-runs ONLY when practiceRange changes)
+  useEffect(() => {
+    if (!user) return
+    const controller = new AbortController()
+    const userId = user.id
+
+    async function fetchPractice() {
+      try {
+        const bounds = getRangeBounds(practiceRange)
+        const { data, error } = await supabase
+          .from('practice_sessions')
+          .select('created_at, duration_minutes')
+          .eq('user_id', userId)
+          .gte('created_at', bounds.start.toISOString())
+          .lt('created_at', bounds.end.toISOString())
+          .order('created_at', { ascending: true })
+          .abortSignal(controller.signal)
+
+        if (error) throw error
+
+        const practiceRows = (data ?? []) as RawPracticeSession[]
+        setPracticeConsistency(buildPracticeBuckets(practiceRows, practiceRange))
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          setFetchError(err instanceof Error ? err.message : 'Failed to load practice data')
+        }
+      }
+    }
+
+    fetchPractice()
+    return () => controller.abort()
+  }, [user, practiceRange])
+
+  // EFFECT 3: Pipeline Data (Re-runs ONLY when pipelineRange changes)
+  useEffect(() => {
+    if (!user) return
+    const controller = new AbortController()
+    const userId = user.id
+
+    async function fetchPipeline() {
+      try {
+        const bounds = getRangeBounds(pipelineRange)
+        const { data, error } = await supabase
+          .from('job_applications')
+          .select('status')
+          .eq('user_id', userId)
+          .gte('created_at', bounds.start.toISOString())
+          .lt('created_at', bounds.end.toISOString())
+          .abortSignal(controller.signal)
+
+        if (error) throw error
+
+        const statuses = (data ?? []).map((row) => row.status).filter(isApplicationStatus)
+        setPipeline({
+          total: statuses.length,
+          interviews: statuses.filter((s) => INTERVIEW_STATUSES.includes(s)).length,
+          offers: statuses.filter((s) => s === 'offer').length,
+        })
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          setFetchError(err instanceof Error ? err.message : 'Failed to load pipeline data')
+        }
+      }
+    }
+
+    fetchPipeline()
+    return () => controller.abort()
+  }, [user, pipelineRange])
+  
+
+  const data: DashboardData | null =
+    !isInitialLoad
+      ? {
+          recentSessions: recentSessions!,
+          companies: companies!,
+          pipeline: pipeline!,
+          practiceConsistency: practiceConsistency!,
+        }
+      : null
 
   return { data, isLoading, fetchError }
 }

--- a/apps/web/src/pages/DashboardPage.module.css
+++ b/apps/web/src/pages/DashboardPage.module.css
@@ -84,16 +84,37 @@
   color: var(--color-text);
 }
 
-.weekPill {
-  display: flex;
+.rangePills {
+  display: inline-flex;
   align-items: center;
   gap: var(--space-1);
+  padding: 2px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-full);
-  /* sub-grid pill sizing: 2px vertical sits below --space-1 (4px), intentional compact design */
-  padding: 2px 10px;
-  font-size: var(--font-sm);
+  background-color: var(--color-bg);
+}
+
+.rangePillBtn {
+  border: none;
+  background: transparent;
   color: var(--color-text-secondary);
+  border-radius: var(--radius-full);
+  padding: 6px 10px;
+  font-size: var(--font-sm);
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.rangePillBtn:hover {
+  color: var(--color-text);
+}
+
+.rangePillBtnActive {
+  background-color: var(--color-text);
+  color: var(--color-bg);
 }
 
 .cardMeta {

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -207,20 +207,20 @@ function TargetCompaniesCard({ companies }: TargetCompaniesCardProps): JSX.Eleme
   )
 }
 
-function AiPromoCard(): JSX.Element {
-  return (
-    <div className={styles.promoCard}>
-      <Zap size={20} className={styles.promoIcon} />
-      <p className={styles.promoTitle}>Unlock AI Mock Interviews</p>
-      <p className={styles.promoSubtitle}>
-        Practice with an AI interviewer tailored to your target role and company.
-      </p>
-      <Link to="/interview" className={styles.promoBtn}>
-        Upgrade Now
-      </Link>
-    </div>
-  )
-}
+//function AiPromoCard(): JSX.Element {
+  //return (
+  //  <div className={styles.promoCard}>
+    //  <Zap size={20} className={styles.promoIcon} />
+     // <p className={styles.promoTitle}>Unlock AI Mock Interviews</p>
+      //<p className={styles.promoSubtitle}>
+        //Practice with an AI interviewer tailored to your target role and company.
+     // <p>
+    //  <Link to="/interview" className={styles.promoBtn}>
+     //   Upgrade Now
+     // </Link>
+   // </div>
+ // )
+//}
 
 function ApplicationPipelineCard({
   range,

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -294,7 +294,10 @@ export default function DashboardPage(): JSX.Element {
       ? { totalMinutes: 0, buckets: [0, 0, 0, 0, 0, 0, 0] }
       : { totalMinutes: 0, buckets: [0, 0, 0, 0, 0] }
 
-  if (isLoading) {
+  const shouldShowInitialLoader = isLoading && !data
+  const shouldShowFullPageError = fetchError && !data
+
+  if (shouldShowInitialLoader) {
     return (
       <div className={styles.loadingState}>
         <Spinner size="lg" />
@@ -302,7 +305,7 @@ export default function DashboardPage(): JSX.Element {
     )
   }
 
-  if (fetchError) {
+  if (shouldShowFullPageError) {
     return (
       <div className={styles.errorState}>
         <p className={styles.errorText}>{fetchError}</p>

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -325,7 +325,7 @@ export default function DashboardPage(): JSX.Element {
           />
           <div className={styles.bottomRow}>
             <TargetCompaniesCard companies={data?.companies ?? []} />
-            <AiPromoCard />
+            
           </div>
         </div>
 

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { TrendingUp, Building2, Calendar, ChevronRight, Zap } from 'lucide-react'
+import { TrendingUp, Building2, Calendar, ChevronRight } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { Badge, Spinner } from '@/components/ui'
 import { GamificationCard } from '@/components/dashboard/GamificationCard'

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,23 +1,34 @@
-import { TrendingUp, Building2, Calendar, ChevronRight } from 'lucide-react'
+import { useState } from 'react'
+import { TrendingUp, Building2, Calendar, ChevronRight, Zap } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { Badge, Spinner } from '@/components/ui'
 import { GamificationCard } from '@/components/dashboard/GamificationCard'
 import { useDashboardData } from '@/hooks/useDashboardData'
 import { cn } from '@/utils/cn'
-import type { ResearchSessionSummary, CompanySummary, PipelineCounts } from '@/types'
+import type {
+  ResearchSessionSummary,
+  CompanySummary,
+  PipelineCounts,
+  DashboardRange,
+  PracticeConsistencyData,
+} from '@/types'
 import styles from './DashboardPage.module.css'
 
-const DAY_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'] as const
-const EMPTY_WEEK_HOURS = [0, 0, 0, 0, 0, 0, 0]
+const WEEK_LABELS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'] as const
+const MONTH_BUCKET_LABELS = ['W1', 'W2', 'W3', 'W4', 'W5'] as const
 
 function formatTimeAgo(isoString: string): string {
   const diffMs = Date.now() - new Date(isoString).getTime()
   const diffMins = Math.floor(diffMs / 60000)
+
   if (diffMins < 1) return 'just now'
+
   const diffHours = Math.floor(diffMins / 60)
   if (diffHours < 1) return `${diffMins}m ago`
+
   const diffDays = Math.floor(diffHours / 24)
   if (diffDays < 1) return `${diffHours}h ago`
+
   return `${diffDays}d ago`
 }
 
@@ -29,13 +40,53 @@ interface TargetCompaniesCardProps {
   companies: CompanySummary[]
 }
 
+interface RangePillsProps {
+  value: DashboardRange
+  onChange: (value: DashboardRange) => void
+}
+
+interface PracticeConsistencyCardProps {
+  range: DashboardRange
+  onRangeChange: (value: DashboardRange) => void
+  data: PracticeConsistencyData
+}
+
 interface ApplicationPipelineCardProps {
+  range: DashboardRange
+  onRangeChange: (value: DashboardRange) => void
   pipeline: PipelineCounts
 }
 
-function PracticeConsistencyCard(): JSX.Element {
-  const today = new Date().getDay()
-  const maxHours = Math.max(...EMPTY_WEEK_HOURS, 1)
+function RangePills({ value, onChange }: RangePillsProps): JSX.Element {
+  return (
+    <div className={styles.rangePills}>
+      <button
+        type="button"
+        className={cn(styles.rangePillBtn, value === 'week' && styles.rangePillBtnActive)}
+        onClick={() => onChange('week')}
+      >
+        This Week
+      </button>
+      <button
+        type="button"
+        className={cn(styles.rangePillBtn, value === 'month' && styles.rangePillBtnActive)}
+        onClick={() => onChange('month')}
+      >
+        This Month
+      </button>
+    </div>
+  )
+}
+
+function PracticeConsistencyCard({
+  range,
+  onRangeChange,
+  data,
+}: PracticeConsistencyCardProps): JSX.Element {
+  const labels = range === 'week' ? WEEK_LABELS : MONTH_BUCKET_LABELS
+  const buckets = data.buckets
+  const maxMinutes = Math.max(...buckets, 1)
+  const totalHours = (data.totalMinutes / 60).toFixed(data.totalMinutes % 60 === 0 ? 0 : 1)
 
   return (
     <div className={styles.card}>
@@ -45,24 +96,26 @@ function PracticeConsistencyCard(): JSX.Element {
             <TrendingUp size={16} className={styles.cardMetaIcon} />
             <span className={styles.cardTitle}>Practice Consistency</span>
           </div>
-          <div className={styles.weekPill}>
-            <span>This Week</span>
-          </div>
+          <RangePills value={range} onChange={onRangeChange} />
         </div>
-        <div className={styles.statValue}>0h</div>
-        <p className={styles.statEmpty}>Start your first session to track consistency</p>
+
+        <div className={styles.statValue}>{totalHours}h</div>
+        <p className={styles.statEmpty}>
+          {data.totalMinutes === 0
+            ? 'Start your first session to track consistency'
+            : range === 'week'
+              ? 'Practice time recorded this ISO week'
+              : 'Practice time recorded this month'}
+        </p>
+
         <div className={styles.barChart}>
-          {DAY_LABELS.map((label, i) => {
-            const heightPct = `${Math.max((EMPTY_WEEK_HOURS[i] / maxHours) * 100, 4)}%`
+          {labels.map((label, i) => {
+            const heightPct = `${Math.max((buckets[i] / maxMinutes) * 100, 4)}%`
+
             return (
-              <div key={`day-${i}`} className={styles.barGroup}>
-                <div
-                  className={cn(styles.bar, i === today && styles.barToday)}
-                  style={{ height: heightPct }}
-                />
-                <span className={cn(styles.barLabel, i === today && styles.barLabelToday)}>
-                  {label}
-                </span>
+              <div key={`bucket-${i}`} className={styles.barGroup}>
+                <div className={styles.bar} style={{ height: heightPct }} />
+                <span className={styles.barLabel}>{label}</span>
               </div>
             )
           })}
@@ -82,6 +135,7 @@ function RecentResearchCard({ sessions }: RecentResearchCardProps): JSX.Element 
             See all <ChevronRight size={12} />
           </Link>
         </div>
+
         {sessions.length === 0 ? (
           <div className={styles.emptyState}>
             <Building2 size={24} className={styles.emptyIcon} />
@@ -127,6 +181,7 @@ function TargetCompaniesCard({ companies }: TargetCompaniesCardProps): JSX.Eleme
             See all <ChevronRight size={12} />
           </Link>
         </div>
+
         {companies.length === 0 ? (
           <div className={styles.emptyState}>
             <p className={styles.emptyText}>No target companies saved</p>
@@ -152,20 +207,41 @@ function TargetCompaniesCard({ companies }: TargetCompaniesCardProps): JSX.Eleme
   )
 }
 
+function AiPromoCard(): JSX.Element {
+  return (
+    <div className={styles.promoCard}>
+      <Zap size={20} className={styles.promoIcon} />
+      <p className={styles.promoTitle}>Unlock AI Mock Interviews</p>
+      <p className={styles.promoSubtitle}>
+        Practice with an AI interviewer tailored to your target role and company.
+      </p>
+      <Link to="/interview" className={styles.promoBtn}>
+        Upgrade Now
+      </Link>
+    </div>
+  )
+}
 
-function ApplicationPipelineCard({ pipeline }: ApplicationPipelineCardProps): JSX.Element {
+function ApplicationPipelineCard({
+  range,
+  onRangeChange,
+  pipeline,
+}: ApplicationPipelineCardProps): JSX.Element {
   return (
     <div className={styles.card}>
       <div className={styles.cardInner}>
         <div className={styles.cardHeaderRow}>
           <span className={styles.cardTitle}>Application Pipeline</span>
-          <div className={styles.weekPill}>
-            <span>This Month</span>
-          </div>
+          <RangePills value={range} onChange={onRangeChange} />
         </div>
+
         {pipeline.total === 0 ? (
           <div className={styles.emptyState}>
-            <p className={styles.emptyText}>No applications tracked yet</p>
+            <p className={styles.emptyText}>
+              {range === 'week'
+                ? 'No applications tracked this week'
+                : 'No applications tracked this month'}
+            </p>
             <Link to="/research" className={styles.emptyAction}>
               Find companies to apply to
             </Link>
@@ -186,6 +262,7 @@ function ApplicationPipelineCard({ pipeline }: ApplicationPipelineCardProps): JS
                 <span className={styles.pipelineValue}>{pipeline.offers}</span>
               </div>
             </div>
+
             <div className={styles.progressTrack}>
               <div
                 className={cn(styles.progressLayer, styles.progressLayerMid)}
@@ -204,7 +281,18 @@ function ApplicationPipelineCard({ pipeline }: ApplicationPipelineCardProps): JS
 }
 
 export default function DashboardPage(): JSX.Element {
-  const { data, isLoading, fetchError } = useDashboardData()
+  const [practiceRange, setPracticeRange] = useState<DashboardRange>('week')
+  const [pipelineRange, setPipelineRange] = useState<DashboardRange>('month')
+
+  const { data, isLoading, fetchError } = useDashboardData({
+    practiceRange,
+    pipelineRange,
+  })
+
+  const practiceFallback =
+    practiceRange === 'week'
+      ? { totalMinutes: 0, buckets: [0, 0, 0, 0, 0, 0, 0] }
+      : { totalMinutes: 0, buckets: [0, 0, 0, 0, 0] }
 
   if (isLoading) {
     return (
@@ -227,15 +315,22 @@ export default function DashboardPage(): JSX.Element {
       <div className={styles.grid}>
         <div className={styles.leftCol}>
           <GamificationCard />
-          <PracticeConsistencyCard />
+          <PracticeConsistencyCard
+            range={practiceRange}
+            onRangeChange={setPracticeRange}
+            data={data?.practiceConsistency ?? practiceFallback}
+          />
           <div className={styles.bottomRow}>
             <TargetCompaniesCard companies={data?.companies ?? []} />
-
+            <AiPromoCard />
           </div>
         </div>
+
         <div className={styles.rightCol}>
           <RecentResearchCard sessions={data?.recentSessions ?? []} />
           <ApplicationPipelineCard
+            range={pipelineRange}
+            onRangeChange={setPipelineRange}
             pipeline={data?.pipeline ?? { total: 0, interviews: 0, offers: 0 }}
           />
         </div>

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -85,6 +85,13 @@ export interface CompanySummary {
   industry: string | null
 }
 
+export type DashboardRange = 'week' | 'month'
+
+export interface PracticeConsistencyData {
+  totalMinutes: number
+  buckets: number[]
+}
+
 export interface PipelineCounts {
   total: number
   interviews: number
@@ -95,6 +102,7 @@ export interface DashboardData {
   recentSessions: ResearchSessionSummary[]
   companies: CompanySummary[]
   pipeline: PipelineCounts
+  practiceConsistency: PracticeConsistencyData
 }
 
 export type ResumeNode = { text?: string }

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -21,7 +21,7 @@ export interface CompanyRole {
   roleTitle: string
   jobDescription: string | null
   companyProfileId: string
-  createdAt?: string
+  createdAt: string
 }
 
 export type {

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -16,6 +16,13 @@ export interface PastJobDescription {
   jobDescription: string
 }
 
+export interface CompanyRole {
+  id: string
+  roleTitle: string
+  jobDescription: string | null
+  companyProfileId: string
+  createdAt?: string
+}
 
 export type {
   ResumeAllowedExtension,


### PR DESCRIPTION
# Changes made
- added week/month filter state for dashboard cards
- filtered practice consistency data based on selected time range
- filtered application pipeline data based on selected time range
- implemented interactive range pills with active/inactive styling
- updated dashboard cards to re-fetch data without full page reload