### PR TITLE
Show saved resumes on Resume page

### DIFF
--- a/apps/web/src/hooks/useResumePersistence.ts
+++ b/apps/web/src/hooks/useResumePersistence.ts
@@ -3,6 +3,7 @@ import type { ResumeDocument, ResumeRecordDto, ResumeRecordStatus } from '@/type
 import {
   createParsedResume,
   getPrimaryResume,
+  getUserResumes,
   saveResumeStructuredContent,
 } from '@/lib/resumeRepository'
 
@@ -23,6 +24,7 @@ type UseResumePersistenceReturn = {
   error: string | null
   clearError: () => void
   loadPrimaryResume: (userId: string) => Promise<ResumeRecordDto | null>
+  loadUserResumes: (userId: string) => Promise<ResumeRecordDto[]>
   createResumeFromParse: (input: CreateParsedResumeParams) => Promise<ResumeRecordDto>
   saveResume: (
     resumeId: string,
@@ -51,6 +53,19 @@ export function useResumePersistence(): UseResumePersistenceReturn {
       return await getPrimaryResume(userId)
     } catch (err) {
       setError(toErrorMessage(err, 'Failed to load resume.'))
+      throw err
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  const loadUserResumes = useCallback(async (userId: string) => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      return await getUserResumes(userId)
+    } catch (err) {
+      setError(toErrorMessage(err, 'Failed to load saved resumes.'))
       throw err
     } finally {
       setIsLoading(false)
@@ -95,6 +110,7 @@ export function useResumePersistence(): UseResumePersistenceReturn {
     error,
     clearError,
     loadPrimaryResume,
+    loadUserResumes,
     createResumeFromParse,
     saveResume,
   }

--- a/apps/web/src/lib/resumeRepository.ts
+++ b/apps/web/src/lib/resumeRepository.ts
@@ -104,6 +104,18 @@ export async function getPrimaryResume(userId: string): Promise<ResumeRecordDto 
   return data ? mapRowToDto(data) : null
 }
 
+export async function getUserResumes(userId: string): Promise<ResumeRecordDto[]> {
+  const { data, error } = await supabase
+    .from('resumes')
+    .select('*')
+    .eq('user_id', userId)
+    .order('updated_at', { ascending: false })
+    .order('created_at', { ascending: false })
+
+  if (error) throw error
+  return (data ?? []).map((row) => mapRowToDto(row as ResumeRow))
+}
+
 export async function createParsedResume(input: CreateParsedResumeInput): Promise<ResumeRecordDto> {
   const { data, error } = await supabase
     .from('resumes')

--- a/apps/web/src/pages/ResearchPage.module.css
+++ b/apps/web/src/pages/ResearchPage.module.css
@@ -146,7 +146,7 @@
   height: 24px;
   border-radius: var(--radius-sm);
   object-fit: contain;
-  background-color: var(--color-bg); 
+  background-color: var(--color-bg);
   flex-shrink: 0;
 }
 
@@ -158,7 +158,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.6875rem; 
+  font-size: 0.6875rem;
   font-weight: 600;
   color: var(--color-text-secondary);
   flex-shrink: 0;
@@ -251,6 +251,7 @@
   background: var(--color-bg-muted);
   color: #f59e0b;
 }
+
 .deleteBtn {
   display: flex;
   align-items: center;
@@ -276,6 +277,7 @@
   background: var(--color-bg-muted);
   color: #dc2626;
 }
+
 .noResults {
   font-size: var(--font-sm);
   color: var(--color-text-tertiary);
@@ -316,7 +318,6 @@
   justify-content: center;
   padding: var(--space-4) 0;
 }
-
 
 .persistentAddContainer .addCompanyBtn {
   width: 100%;
@@ -490,6 +491,73 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+}
+
+/* Input area */
+
+.inputArea {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.hiddenFileInput {
+  display: none;
+}
+
+.fileAlert {
+  margin: 0 var(--space-4);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid #f59e0b;
+  border-radius: var(--radius-md);
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--color-text);
+  font-size: var(--font-sm);
+}
+
+.selectedFileRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin: 0 var(--space-4);
+}
+
+.selectedFileChip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  max-width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background: var(--color-bg-subtle);
+  color: var(--color-text);
+  font-size: var(--font-sm);
+}
+
+.selectedFileName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.selectedFileRemove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.selectedFileRemove:hover {
+  background: var(--color-bg-subtle);
+  color: var(--color-text);
 }
 
 /* Input bar */

--- a/apps/web/src/pages/ResearchPage.module.css
+++ b/apps/web/src/pages/ResearchPage.module.css
@@ -146,7 +146,7 @@
   height: 24px;
   border-radius: var(--radius-sm);
   object-fit: contain;
-  background-color: var(--color-bg);
+  background-color: var(--color-bg); 
   flex-shrink: 0;
 }
 
@@ -158,7 +158,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.6875rem;
+  font-size: 0.6875rem; 
   font-weight: 600;
   color: var(--color-text-secondary);
   flex-shrink: 0;
@@ -251,7 +251,6 @@
   background: var(--color-bg-muted);
   color: #f59e0b;
 }
-
 .deleteBtn {
   display: flex;
   align-items: center;
@@ -276,6 +275,239 @@
 .deleteBtn:hover {
   background: var(--color-bg-muted);
   color: #dc2626;
+}
+
+/* Expand button */
+
+.expandBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-tertiary);
+  padding: 0;
+  flex-shrink: 0;
+  transition: color 0.15s;
+}
+
+.expandBtn:hover {
+  color: var(--color-text);
+}
+
+/* ── Role list ──────────────────────────────────────────────────────────── */
+
+.roleList {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0 0 var(--space-2) var(--space-6);
+  margin-top: -2px;
+}
+
+.roleItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.375rem 0.5rem;
+  border-radius: var(--radius-md);
+  transition: background-color 0.15s;
+}
+
+.roleItem:hover {
+  background: var(--color-bg-muted);
+}
+
+.roleItemActive {
+  background: var(--color-primary-subtle);
+}
+
+.roleSelectBtn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text);
+  font-size: var(--font-xs);
+  font-weight: 500;
+  padding: 0;
+  min-width: 0;
+  flex: 1;
+}
+
+.roleName {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.roleActions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.15s;
+  flex-shrink: 0;
+}
+
+.roleItem:hover .roleActions {
+  opacity: 1;
+}
+
+.roleInterviewBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-primary);
+  padding: 0;
+  transition: background-color 0.15s;
+}
+
+.roleInterviewBtn:hover {
+  background: var(--color-primary-subtle);
+}
+
+.roleDeleteBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-tertiary);
+  padding: 0;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.roleDeleteBtn:hover {
+  background: var(--color-bg-muted);
+  color: #dc2626;
+}
+
+.roleEmpty {
+  font-size: var(--font-xs);
+  color: var(--color-text-tertiary);
+  padding: var(--space-1) 0;
+}
+
+/* Add role inline form */
+
+.addRoleBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: var(--font-xs);
+  font-weight: 500;
+  color: var(--color-primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.375rem 0.5rem;
+  border-radius: var(--radius-md);
+  transition: background-color 0.15s;
+}
+
+.addRoleBtn:hover {
+  background: var(--color-primary-subtle);
+}
+
+.addRoleForm {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+}
+
+.addRoleInput {
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  font-size: var(--font-xs);
+  font-family: inherit;
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.addRoleInput:focus {
+  border-color: var(--color-primary);
+}
+
+.addRoleJdInput {
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  font-size: var(--font-xs);
+  font-family: inherit;
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+  resize: vertical;
+  transition: border-color 0.15s;
+}
+
+.addRoleJdInput:focus {
+  border-color: var(--color-primary);
+}
+
+.addRoleFormActions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.addRoleSaveBtn {
+  font-size: var(--font-xs);
+  font-weight: 500;
+  color: #fff;
+  background: var(--color-primary);
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 0.25rem 0.625rem;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.addRoleSaveBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.addRoleSaveBtn:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.addRoleCancelBtn {
+  font-size: var(--font-xs);
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0.25rem 0.625rem;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.addRoleCancelBtn:hover {
+  background: var(--color-bg-muted);
 }
 
 .noResults {
@@ -318,6 +550,7 @@
   justify-content: center;
   padding: var(--space-4) 0;
 }
+
 
 .persistentAddContainer .addCompanyBtn {
   width: 100%;
@@ -493,73 +726,6 @@
   flex-shrink: 0;
 }
 
-/* Input area */
-
-.inputArea {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-}
-
-.hiddenFileInput {
-  display: none;
-}
-
-.fileAlert {
-  margin: 0 var(--space-4);
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid #f59e0b;
-  border-radius: var(--radius-md);
-  background: rgba(245, 158, 11, 0.12);
-  color: var(--color-text);
-  font-size: var(--font-sm);
-}
-
-.selectedFileRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-  margin: 0 var(--space-4);
-}
-
-.selectedFileChip {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  max-width: 100%;
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-full);
-  background: var(--color-bg-subtle);
-  color: var(--color-text);
-  font-size: var(--font-sm);
-}
-
-.selectedFileName {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.selectedFileRemove {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border: none;
-  border-radius: var(--radius-full);
-  background: transparent;
-  color: var(--color-text-secondary);
-  cursor: pointer;
-}
-
-.selectedFileRemove:hover {
-  background: var(--color-bg-subtle);
-  color: var(--color-text);
-}
-
 /* Input bar */
 
 .inputBar {
@@ -635,4 +801,71 @@
 
 .sendBtnActive:hover {
   background: var(--color-primary-hover);
+}
+
+/* ── File upload (Issue #116) ───────────────────────────────────────────── */
+
+.inputArea {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.hiddenFileInput {
+  display: none;
+}
+
+.fileAlert {
+  margin: 0 var(--space-4);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid #f59e0b;
+  border-radius: var(--radius-md);
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--color-text);
+  font-size: var(--font-sm);
+}
+
+.selectedFileRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin: 0 var(--space-4);
+}
+
+.selectedFileChip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  max-width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background: var(--color-bg-subtle);
+  color: var(--color-text);
+  font-size: var(--font-sm);
+}
+
+.selectedFileName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.selectedFileRemove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.selectedFileRemove:hover {
+  background: var(--color-bg-subtle);
+  color: var(--color-text);
 }

--- a/apps/web/src/pages/ResearchPage.tsx
+++ b/apps/web/src/pages/ResearchPage.tsx
@@ -3,19 +3,26 @@ import {
   Plus,
   Search,
   Send,
-  GripVertical,
   X,
   Paperclip,
   Star,
   Trash2,
+  ChevronRight,
+  ChevronDown,
+  Play,
+  Briefcase,
   FileText,
 } from 'lucide-react'
 import { useNavigate, useLocation } from 'react-router-dom'
-import { Button } from '@/components/ui'
 import { useAuth } from '@/contexts/AuthContext'
 import { useResearchChat } from '@/hooks/useResearchChat'
 import { useResearchCompanies } from '@/hooks/useResearchCompanies'
+import { useCompanyRoles } from '@/hooks/useCompanyRoles'
+import { StandardToast } from '@/components/interview/Toast'
+import AddCompanyModal from './AddCompanyPage'
 import { cn } from '@/utils/cn'
+import { ConfirmModal } from '@/utils/ConfirmModal'
+import type { CompanyRole } from '@/types'
 import styles from './ResearchPage.module.css'
 
 interface CompanyProfile {
@@ -24,6 +31,11 @@ interface CompanyProfile {
   category: string
   isFavorite: boolean
   company_website?: string
+}
+
+interface ActiveContextItem {
+  company: CompanyProfile
+  role?: CompanyRole
 }
 
 const CATEGORY_STYLE: Record<string, string> = {
@@ -36,13 +48,7 @@ const CATEGORY_STYLE: Record<string, string> = {
   SaaS: styles.categorySaas,
 }
 
-function CompanyLogo({
-  company,
-  styles,
-}: {
-  company: CompanyProfile
-  styles: Record<string, string>
-}) {
+function CompanyLogo({ company, styles }: { company: CompanyProfile; styles: Record<string, string> }) {
   const [hasError, setHasError] = useState(false)
 
   if (!company.company_website || hasError) {
@@ -62,20 +68,58 @@ function CompanyLogo({
 export default function ResearchPage() {
   const navigate = useNavigate()
   const location = useLocation()
+
   const [searchQuery, setSearchQuery] = useState(() => {
     return location.state?.companyName || ''
   })
-  const [activeContext, setActiveContext] = useState<CompanyProfile[]>([])
+
+  const [activeContext, setActiveContext] = useState<ActiveContextItem[]>([])
   const [input, setInput] = useState('')
+  const [isDragOver, setIsDragOver] = useState(false)
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false)
+  const [toastConfig, setToastConfig] = useState<{ message: string; variant: 'success' | 'error' } | null>(null)
+  const [companyToDelete, setCompanyToDelete] = useState<{ id: string; name: string } | null>(null)
+
+  // File upload state for issue #116
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
   const [fileAlert, setFileAlert] = useState<string | null>(null)
-  const [isDragOver, setIsDragOver] = useState(false)
-  const draggingCompany = useRef<CompanyProfile | null>(null)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
+  const draggingCompany = useRef<CompanyProfile | null>(null)
   const { user } = useAuth()
-  const { companies: dbCompanies, isLoading, toggleFavorite, deleteCompany } =
+  const { companies: dbCompanies, isLoading, toggleFavorite, deleteCompany, refreshCompanies } =
     useResearchCompanies()
+
+  // Expandable roles state
+  const [expandedCompanyId, setExpandedCompanyId] = useState<string | null>(
+    (location.state as { companyProfileId?: string } | null)?.companyProfileId || null
+  )
+  const { roles, isLoading: rolesLoading, addRole, deleteRole } = useCompanyRoles(expandedCompanyId)
+
+  // Add role inline form state
+  const [isAddingRole, setIsAddingRole] = useState(false)
+  const [newRoleTitle, setNewRoleTitle] = useState('')
+  const [newRoleJd, setNewRoleJd] = useState('')
+  const roleInputRef = useRef<HTMLInputElement>(null)
+
+  // Auto-expand and select role from location state
+  const appliedLocationState = useRef(false)
+  useEffect(() => {
+    if (appliedLocationState.current) return
+
+    const state = location.state as { companyProfileId?: string; roleId?: string } | null
+    if (state?.roleId && roles.length > 0) {
+      appliedLocationState.current = true
+      const role = roles.find((r) => r.id === state.roleId)
+
+      if (role && dbCompanies.length > 0) {
+        const company = dbCompanies.find((c) => c.id === state.companyProfileId)
+        if (company && !activeContext.find((ctx) => ctx.role?.id === role.id)) {
+          setActiveContext((prev) => [...prev, { company, role }])
+        }
+      }
+    }
+  }, [location.state, roles, dbCompanies, activeContext])
 
   useEffect(() => {
     if (location.state?.newCompanyId && dbCompanies.length > 0) {
@@ -91,10 +135,15 @@ export default function ResearchPage() {
 
   const userInitial = user?.email?.[0].toUpperCase() ?? '?'
 
-  const companyNames = activeContext.map((c) => c.name)
-  const { messages, isStreaming, sendMessage, resetMessages } = useResearchChat({
+  const activeRole = activeContext.length === 1 ? activeContext[0].role : undefined
+  const activeCompanyProfileId = activeContext.length === 1 ? activeContext[0].company.id : undefined
+  const companyNames = activeContext.map((ctx) => ctx.company.name)
+
+  const { messages, isStreaming, sendMessage } = useResearchChat({
     companies: companyNames,
-    jobDescription: undefined,
+    jobDescription: activeRole?.jobDescription || undefined,
+    companyProfileId: activeCompanyProfileId || null,
+    roleId: activeRole?.id || null,
   })
 
   const filteredCompanies = dbCompanies
@@ -105,10 +154,21 @@ export default function ResearchPage() {
     toggleFavorite(id)
   }
 
-  const handleDeleteCompany = async (id: string, name: string) => {
-    if (confirm(`Delete "${name}" from your saved companies?`)) {
+  const handleDeleteCompany = async () => {
+    if (!companyToDelete) return
+
+    const { id, name } = companyToDelete
+
+    try {
       await deleteCompany(id)
+      setToastConfig({ message: `Removed ${name} from your board`, variant: 'error' })
+    } catch (error) {
+      console.error(`Failed to delete company ${id}:`, error)
+      const errorMessage = error instanceof Error ? error.message : 'Please try again later.'
+      setToastConfig({ message: `Failed to delete ${name}: ${errorMessage}`, variant: 'error' })
     }
+
+    setCompanyToDelete(null)
   }
 
   function handleDragStart(company: CompanyProfile) {
@@ -118,11 +178,14 @@ export default function ResearchPage() {
   function handleDrop(e: React.DragEvent) {
     e.preventDefault()
     setIsDragOver(false)
+
     const company = draggingCompany.current
     if (!company) return
-    if (!activeContext.find((c) => c.id === company.id)) {
-      setActiveContext((prev) => [...prev, company])
+
+    if (!activeContext.find((ctx) => ctx.company.id === company.id && !ctx.role)) {
+      setActiveContext((prev) => [...prev, { company }])
     }
+
     draggingCompany.current = null
   }
 
@@ -137,16 +200,69 @@ export default function ResearchPage() {
     }
   }
 
-  function removeFromContext(id: string) {
-    setActiveContext((prev) => prev.filter((c) => c.id !== id))
+  function removeFromContext(companyId: string, roleId?: string) {
+    setActiveContext((prev) =>
+      prev.filter((ctx) => !(ctx.company.id === companyId && ctx.role?.id === roleId))
+    )
   }
 
-  function handleNewBoard() {
-    setActiveContext([])
-    resetMessages()
+  function handleSend() {
+    const trimmed = input.trim()
+    if (!trimmed || isStreaming) return
     setInput('')
-    setSelectedFile(null)
-    setFileAlert(null)
+    sendMessage(trimmed)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSend()
+    }
+  }
+
+  function handleToggleExpand(companyId: string) {
+    setExpandedCompanyId((prev) => (prev === companyId ? null : companyId))
+    setIsAddingRole(false)
+    setNewRoleTitle('')
+    setNewRoleJd('')
+  }
+
+  function handleSelectRole(company: CompanyProfile, role: CompanyRole) {
+    if (!activeContext.find((ctx) => ctx.role?.id === role.id)) {
+      setActiveContext((prev) => [...prev, { company, role }])
+    }
+  }
+
+  function handleStartInterview(company: CompanyProfile, role: CompanyRole) {
+    navigate('/interview', {
+      state: {
+        companyName: company.name,
+        companyProfileId: company.id,
+        roleId: role.id,
+        roleTitle: role.roleTitle,
+        jobDescription: role.jobDescription || '',
+      },
+    })
+  }
+
+  async function handleAddRole() {
+    const title = newRoleTitle.trim()
+    if (!title) return
+
+    const result = await addRole(title, newRoleJd || undefined)
+    if (result) {
+      setToastConfig({ message: `Added role "${title}"`, variant: 'success' })
+    }
+
+    setNewRoleTitle('')
+    setNewRoleJd('')
+    setIsAddingRole(false)
+  }
+
+  async function handleDeleteRole(roleId: string, roleTitle: string) {
+    await deleteRole(roleId)
+    setActiveContext((prev) => prev.filter((ctx) => ctx.role?.id !== roleId))
+    setToastConfig({ message: `Removed role "${roleTitle}"`, variant: 'error' })
   }
 
   function handleAttachClick() {
@@ -176,20 +292,6 @@ export default function ResearchPage() {
     setFileAlert(null)
   }
 
-  function handleSend() {
-    const trimmed = input.trim()
-    if (!trimmed || isStreaming) return
-    setInput('')
-    sendMessage(trimmed)
-  }
-
-  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
-      handleSend()
-    }
-  }
-
   return (
     <div className={styles.page}>
       <div className={styles.header}>
@@ -199,10 +301,6 @@ export default function ResearchPage() {
             Chat with AI to analyze companies, compare roles, and build your knowledge base
           </p>
         </div>
-        <Button variant="primary" size="sm" onClick={handleNewBoard}>
-          <Plus size={14} />
-          New Board
-        </Button>
       </div>
 
       <div className={styles.layout}>
@@ -217,55 +315,172 @@ export default function ResearchPage() {
             />
           </div>
 
-          <p className={styles.sidebarLabel}>Saved Profiles (Drag to Chat)</p>
+          <p className={styles.sidebarLabel}>Saved Profiles</p>
 
           <div className={styles.companyList}>
             {filteredCompanies.map((company) => (
-              <div
-                key={company.id}
-                className={styles.companyCard}
-                draggable
-                onDragStart={() => handleDragStart(company)}
-              >
-                <GripVertical size={14} className={styles.dragHandle} />
-                <CompanyLogo company={company} styles={styles} />
-                <div className={styles.companyInfo}>
-                  <span className={styles.companyName}>{company.name}</span>
-                  <span
-                    className={cn(
-                      styles.categoryBadge,
-                      CATEGORY_STYLE[company.category] ?? styles.categoryDefault,
-                    )}
+              <div key={company.id}>
+                <div
+                  className={styles.companyCard}
+                  draggable
+                  onDragStart={() => handleDragStart(company)}
+                >
+                  <button
+                    className={styles.expandBtn}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handleToggleExpand(company.id)
+                    }}
+                    aria-label={expandedCompanyId === company.id ? 'Collapse' : 'Expand'}
                   >
-                    {company.category}
-                  </span>
+                    {expandedCompanyId === company.id ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                  </button>
+
+                  <CompanyLogo company={company} styles={styles} />
+
+                  <div className={styles.companyInfo}>
+                    <span className={styles.companyName}>{company.name}</span>
+                    <span
+                      className={cn(
+                        styles.categoryBadge,
+                        CATEGORY_STYLE[company.category] ?? styles.categoryDefault
+                      )}
+                    >
+                      {company.category}
+                    </span>
+                  </div>
+
+                  <button
+                    className={cn(styles.starBtn, company.isFavorite && styles.starBtnActive)}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handleToggleFavorite(company.id)
+                    }}
+                    aria-label={company.isFavorite ? 'Unfavorite' : 'Favorite'}
+                  >
+                    <Star size={13} />
+                  </button>
+
+                  <button
+                    className={styles.deleteBtn}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setCompanyToDelete({ id: company.id, name: company.name })
+                    }}
+                    aria-label={`Delete ${company.name}`}
+                  >
+                    <Trash2 size={13} />
+                  </button>
                 </div>
-                <button
-                  className={cn(styles.starBtn, company.isFavorite && styles.starBtnActive)}
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    handleToggleFavorite(company.id)
-                  }}
-                  aria-label={company.isFavorite ? 'Unfavorite' : 'Favorite'}
-                >
-                  <Star size={13} />
-                </button>
-                <button
-                  className={styles.deleteBtn}
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    handleDeleteCompany(company.id, company.name)
-                  }}
-                  aria-label={`Delete ${company.name}`}
-                >
-                  <Trash2 size={13} />
-                </button>
+
+                {expandedCompanyId === company.id && (
+                  <div className={styles.roleList}>
+                    {rolesLoading && roles.length === 0 && <p className={styles.roleEmpty}>Loading roles...</p>}
+
+                    {!rolesLoading && roles.length === 0 && !isAddingRole && (
+                      <p className={styles.roleEmpty}>No roles yet</p>
+                    )}
+
+                    {roles.map((role) => (
+                      <div
+                        key={role.id}
+                        className={cn(
+                          styles.roleItem,
+                          activeContext.find((ctx) => ctx.role?.id === role.id) && styles.roleItemActive
+                        )}
+                      >
+                        <button
+                          className={styles.roleSelectBtn}
+                          onClick={() => handleSelectRole(company, role)}
+                          title="Add to research context"
+                        >
+                          <Briefcase size={11} />
+                          <span className={styles.roleName}>{role.roleTitle}</span>
+                        </button>
+
+                        <div className={styles.roleActions}>
+                          <button
+                            className={styles.roleInterviewBtn}
+                            onClick={() => handleStartInterview(company, role)}
+                            title="Start interview"
+                          >
+                            <Play size={11} />
+                          </button>
+
+                          <button
+                            className={styles.roleDeleteBtn}
+                            onClick={() => handleDeleteRole(role.id, role.roleTitle)}
+                            title="Delete role"
+                          >
+                            <Trash2 size={11} />
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+
+                    {isAddingRole ? (
+                      <div className={styles.addRoleForm}>
+                        <input
+                          ref={roleInputRef}
+                          className={styles.addRoleInput}
+                          placeholder="Role title (e.g. SWE Intern)"
+                          value={newRoleTitle}
+                          onChange={(e) => setNewRoleTitle(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') handleAddRole()
+                            if (e.key === 'Escape') {
+                              setIsAddingRole(false)
+                              setNewRoleTitle('')
+                              setNewRoleJd('')
+                            }
+                          }}
+                          autoFocus
+                        />
+                        <textarea
+                          className={styles.addRoleJdInput}
+                          placeholder="Job description (optional)"
+                          value={newRoleJd}
+                          onChange={(e) => setNewRoleJd(e.target.value)}
+                          rows={2}
+                        />
+                        <div className={styles.addRoleFormActions}>
+                          <button
+                            className={styles.addRoleSaveBtn}
+                            onClick={handleAddRole}
+                            disabled={!newRoleTitle.trim()}
+                          >
+                            Add
+                          </button>
+                          <button
+                            className={styles.addRoleCancelBtn}
+                            onClick={() => {
+                              setIsAddingRole(false)
+                              setNewRoleTitle('')
+                              setNewRoleJd('')
+                            }}
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <button
+                        className={styles.addRoleBtn}
+                        onClick={() => {
+                          setIsAddingRole(true)
+                          setTimeout(() => roleInputRef.current?.focus(), 0)
+                        }}
+                      >
+                        <Plus size={11} />
+                        Add Role
+                      </button>
+                    )}
+                  </div>
+                )}
               </div>
             ))}
 
-            {isLoading && filteredCompanies.length === 0 && (
-              <p className={styles.noResults}>Loading companies...</p>
-            )}
+            {isLoading && filteredCompanies.length === 0 && <p className={styles.noResults}>Loading companies...</p>}
 
             {filteredCompanies.length === 0 && !isLoading && (
               <div className={styles.noResultsContainer}>
@@ -275,10 +490,7 @@ export default function ResearchPage() {
 
             {searchQuery.trim() && (
               <div className={styles.persistentAddContainer}>
-                <button
-                  className={styles.addCompanyBtn}
-                  onClick={() => navigate('/add-company', { state: { companyName: searchQuery } })}
-                >
+                <button className={styles.addCompanyBtn} onClick={() => setIsAddModalOpen(true)}>
                   + Add "{searchQuery}" as new company
                 </button>
               </div>
@@ -295,52 +507,44 @@ export default function ResearchPage() {
           >
             <span className={styles.contextLabel}>Active Context:</span>
             <div className={styles.contextChips}>
-              {activeContext.map((company) => (
-                <span key={company.id} className={styles.chip}>
-                  {company.name}
+              {activeContext.map((ctx) => (
+                <span key={`${ctx.company.id}-${ctx.role?.id || 'no-role'}`} className={styles.chip}>
+                  {ctx.role ? `${ctx.company.name} — ${ctx.role.roleTitle}` : ctx.company.name}
                   <button
                     className={styles.chipRemove}
-                    onClick={() => removeFromContext(company.id)}
-                    aria-label={`Remove ${company.name} from context`}
+                    onClick={() => removeFromContext(ctx.company.id, ctx.role?.id)}
+                    aria-label={`Remove ${ctx.company.name} from context`}
                   >
                     <X size={10} />
                   </button>
                 </span>
               ))}
-              <span
-                className={cn(styles.dropHint, activeContext.length > 0 && styles.dropHintSmall)}
-              >
+              <span className={cn(styles.dropHint, activeContext.length > 0 && styles.dropHintSmall)}>
                 + Drop company here
               </span>
             </div>
           </div>
 
           <div className={styles.messages}>
-            {messages.length === 0 ? (
-              <div className={styles.emptyChat}>
-                <p>Hi! I&apos;m your AI researcher. Drag a company into the context bar above, then ask anything.</p>
-              </div>
-            ) : (
-              messages.map((msg) => (
+            {messages.map((msg) => (
+              <div
+                key={msg.id}
+                className={cn(
+                  styles.messageRow,
+                  msg.role === 'user' ? styles.messageRowUser : styles.messageRowAssistant
+                )}
+              >
                 <div
-                  key={msg.id}
                   className={cn(
-                    styles.messageRow,
-                    msg.role === 'user' ? styles.messageRowUser : styles.messageRowAssistant,
+                    styles.message,
+                    msg.role === 'user' ? styles.messageUser : styles.messageAssistant
                   )}
                 >
-                  <div
-                    className={cn(
-                      styles.message,
-                      msg.role === 'user' ? styles.messageUser : styles.messageAssistant,
-                    )}
-                  >
-                    {msg.content}
-                  </div>
-                  {msg.role === 'user' && <span className={styles.avatar}>{userInitial}</span>}
+                  {msg.content}
                 </div>
-              ))
-            )}
+                {msg.role === 'user' && <span className={styles.avatar}>{userInitial}</span>}
+              </div>
+            ))}
           </div>
 
           <div className={styles.inputArea}>
@@ -396,7 +600,7 @@ export default function ResearchPage() {
               <button
                 className={cn(
                   styles.sendBtn,
-                  input.trim() && activeContext.length > 0 && !isStreaming && styles.sendBtnActive,
+                  input.trim() && activeContext.length > 0 && !isStreaming && styles.sendBtnActive
                 )}
                 onClick={handleSend}
                 disabled={!input.trim() || activeContext.length === 0 || isStreaming}
@@ -408,6 +612,35 @@ export default function ResearchPage() {
           </div>
         </div>
       </div>
+
+      <AddCompanyModal
+        isOpen={isAddModalOpen}
+        onClose={() => setIsAddModalOpen(false)}
+        initialCompanyName={searchQuery}
+        onSuccess={async (_newId, newName) => {
+          setIsAddModalOpen(false)
+          setSearchQuery(newName)
+          await refreshCompanies()
+          setToastConfig({ message: `Added ${newName} to your board!`, variant: 'success' })
+        }}
+      />
+
+      <ConfirmModal
+        isOpen={!!companyToDelete}
+        title="Delete Company"
+        message={`Are you sure you want to remove "${companyToDelete?.name}" from your board? This action cannot be undone.`}
+        confirmText="Delete"
+        onCancel={() => setCompanyToDelete(null)}
+        onConfirm={handleDeleteCompany}
+      />
+
+      {toastConfig && (
+        <StandardToast
+          message={toastConfig.message}
+          variant={toastConfig.variant}
+          onDone={() => setToastConfig(null)}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/src/pages/ResearchPage.tsx
+++ b/apps/web/src/pages/ResearchPage.tsx
@@ -1,14 +1,21 @@
 import { useState, useRef, useEffect } from 'react'
-import { Plus, Search, Send, GripVertical, X, Paperclip, Star, Trash2 } from 'lucide-react'
+import {
+  Plus,
+  Search,
+  Send,
+  GripVertical,
+  X,
+  Paperclip,
+  Star,
+  Trash2,
+  FileText,
+} from 'lucide-react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { Button } from '@/components/ui'
 import { useAuth } from '@/contexts/AuthContext'
 import { useResearchChat } from '@/hooks/useResearchChat'
 import { useResearchCompanies } from '@/hooks/useResearchCompanies'
-import { StandardToast } from '@/components/interview/Toast' 
-import AddCompanyModal from './AddCompanyPage'
 import { cn } from '@/utils/cn'
-import { ConfirmModal } from '@/utils/ConfirmModal' 
 import styles from './ResearchPage.module.css'
 
 interface CompanyProfile {
@@ -18,7 +25,6 @@ interface CompanyProfile {
   isFavorite: boolean
   company_website?: string
 }
-
 
 const CATEGORY_STYLE: Record<string, string> = {
   Technology: styles.categoryTechnology,
@@ -30,41 +36,46 @@ const CATEGORY_STYLE: Record<string, string> = {
   SaaS: styles.categorySaas,
 }
 
-function CompanyLogo({ company, styles }: { company: CompanyProfile, styles: Record<string, string> }) {
-  const [hasError, setHasError] = useState(false);
+function CompanyLogo({
+  company,
+  styles,
+}: {
+  company: CompanyProfile
+  styles: Record<string, string>
+}) {
+  const [hasError, setHasError] = useState(false)
+
   if (!company.company_website || hasError) {
-    return (
-      <div className={styles.logoFallback}>
-        {company.name.charAt(0).toUpperCase()}
-      </div>
-    );
+    return <div className={styles.logoFallback}>{company.name.charAt(0).toUpperCase()}</div>
   }
+
   return (
-    <img 
-      src={`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/company-logo?domain=${encodeURIComponent(company.company_website)}`} 
+    <img
+      src={`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/company-logo?domain=${encodeURIComponent(company.company_website)}`}
       alt={`${company.name} logo`}
       className={styles.logoImage}
       onError={() => setHasError(true)}
     />
-  );
+  )
 }
 
 export default function ResearchPage() {
   const navigate = useNavigate()
   const location = useLocation()
   const [searchQuery, setSearchQuery] = useState(() => {
-    return location.state?.companyName || '';
-  });
+    return location.state?.companyName || ''
+  })
   const [activeContext, setActiveContext] = useState<CompanyProfile[]>([])
   const [input, setInput] = useState('')
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [fileAlert, setFileAlert] = useState<string | null>(null)
   const [isDragOver, setIsDragOver] = useState(false)
-  const [isAddModalOpen, setIsAddModalOpen] = useState(false)
   const draggingCompany = useRef<CompanyProfile | null>(null)
-  const { user } = useAuth()
-  const { companies: dbCompanies, isLoading, toggleFavorite, deleteCompany, refreshCompanies } = useResearchCompanies()
-  const [toastConfig, setToastConfig] = useState<{ message: string; variant: 'success' | 'error' } | null>(null)
-  const [companyToDelete, setCompanyToDelete] = useState<{ id: string, name: string } | null>(null)
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
 
+  const { user } = useAuth()
+  const { companies: dbCompanies, isLoading, toggleFavorite, deleteCompany } =
+    useResearchCompanies()
 
   useEffect(() => {
     if (location.state?.newCompanyId && dbCompanies.length > 0) {
@@ -73,10 +84,11 @@ export default function ResearchPage() {
         setSearchQuery(newCompany.name)
         const newState = { ...location.state }
         delete newState.newCompanyId
-        navigate(location.pathname, { replace: true, state: newState });
+        navigate(location.pathname, { replace: true, state: newState })
       }
     }
   }, [location.state, dbCompanies, navigate, location.pathname, searchQuery])
+
   const userInitial = user?.email?.[0].toUpperCase() ?? '?'
 
   const companyNames = activeContext.map((c) => c.name)
@@ -88,26 +100,15 @@ export default function ResearchPage() {
   const filteredCompanies = dbCompanies
     .filter((c) => c.name.toLowerCase().includes(searchQuery.toLowerCase()))
     .sort((a, b) => Number(b.isFavorite) - Number(a.isFavorite))
+
   const handleToggleFavorite = (id: string) => {
     toggleFavorite(id)
   }
-  // function toggleFavorite(id: string) {
-  //   setCompanies((prev) =>
-  //     prev.map((c) => (c.id === id ? { ...c, isFavorite: !c.isFavorite } : c)),
-  //   )
-  // }
-  const handleDeleteCompany = async () => {
-    if (!companyToDelete) return;
-    const { id, name } = companyToDelete;
-    try {
-        await deleteCompany(id)
-        setToastConfig({ message: `Removed ${name} from your board`, variant: 'error' })
-    } catch (error) {
-        console.error(`Failed to delete company ${id}:`, error);
-        const errorMessage = error instanceof Error ? error.message : 'Please try again later.';
-        setToastConfig({ message: `Failed to delete ${name}: ${errorMessage}`, variant: 'error' })
+
+  const handleDeleteCompany = async (id: string, name: string) => {
+    if (confirm(`Delete "${name}" from your saved companies?`)) {
+      await deleteCompany(id)
     }
-    setCompanyToDelete(null);
   }
 
   function handleDragStart(company: CompanyProfile) {
@@ -144,6 +145,35 @@ export default function ResearchPage() {
     setActiveContext([])
     resetMessages()
     setInput('')
+    setSelectedFile(null)
+    setFileAlert(null)
+  }
+
+  function handleAttachClick() {
+    fileInputRef.current?.click()
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = e.target.files
+
+    if (!files || files.length === 0) {
+      return
+    }
+
+    if (files.length > 1) {
+      setFileAlert('You can only upload one file in Research Board chat.')
+      setSelectedFile(files[0])
+    } else {
+      setFileAlert(null)
+      setSelectedFile(files[0])
+    }
+
+    e.target.value = ''
+  }
+
+  function handleRemoveSelectedFile() {
+    setSelectedFile(null)
+    setFileAlert(null)
   }
 
   function handleSend() {
@@ -176,7 +206,6 @@ export default function ResearchPage() {
       </div>
 
       <div className={styles.layout}>
-        {/* Left sidebar */}
         <aside className={styles.sidebar}>
           <div className={styles.searchWrapper}>
             <Search size={14} className={styles.searchIcon} />
@@ -213,7 +242,10 @@ export default function ResearchPage() {
                 </div>
                 <button
                   className={cn(styles.starBtn, company.isFavorite && styles.starBtnActive)}
-                  onClick={(e) => { e.stopPropagation(); handleToggleFavorite(company.id) }}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleToggleFavorite(company.id)
+                  }}
                   aria-label={company.isFavorite ? 'Unfavorite' : 'Favorite'}
                 >
                   <Star size={13} />
@@ -221,8 +253,8 @@ export default function ResearchPage() {
                 <button
                   className={styles.deleteBtn}
                   onClick={(e) => {
-                    e.stopPropagation(); 
-                    setCompanyToDelete({ id: company.id, name: company.name });
+                    e.stopPropagation()
+                    handleDeleteCompany(company.id, company.name)
                   }}
                   aria-label={`Delete ${company.name}`}
                 >
@@ -230,7 +262,7 @@ export default function ResearchPage() {
                 </button>
               </div>
             ))}
-            
+
             {isLoading && filteredCompanies.length === 0 && (
               <p className={styles.noResults}>Loading companies...</p>
             )}
@@ -245,7 +277,7 @@ export default function ResearchPage() {
               <div className={styles.persistentAddContainer}>
                 <button
                   className={styles.addCompanyBtn}
-                  onClick={() => setIsAddModalOpen(true)}
+                  onClick={() => navigate('/add-company', { state: { companyName: searchQuery } })}
                 >
                   + Add "{searchQuery}" as new company
                 </button>
@@ -254,9 +286,7 @@ export default function ResearchPage() {
           </div>
         </aside>
 
-        {/* Chat panel */}
         <div className={styles.chatPanel}>
-          {/* Active Context bar */}
           <div
             className={cn(styles.contextBar, isDragOver && styles.contextBarOver)}
             onDrop={handleDrop}
@@ -278,19 +308,20 @@ export default function ResearchPage() {
                 </span>
               ))}
               <span
-                className={cn(
-                  styles.dropHint,
-                  activeContext.length > 0 && styles.dropHintSmall,
-                )}
+                className={cn(styles.dropHint, activeContext.length > 0 && styles.dropHintSmall)}
               >
                 + Drop company here
               </span>
             </div>
           </div>
 
-          {/* Messages area */}
           <div className={styles.messages}>
-            {messages.map((msg) => (
+            {messages.length === 0 ? (
+              <div className={styles.emptyChat}>
+                <p>Hi! I&apos;m your AI researcher. Drag a company into the context bar above, then ask anything.</p>
+              </div>
+            ) : (
+              messages.map((msg) => (
                 <div
                   key={msg.id}
                   className={cn(
@@ -306,67 +337,77 @@ export default function ResearchPage() {
                   >
                     {msg.content}
                   </div>
-                  {msg.role === 'user' && (
-                    <span className={styles.avatar}>{userInitial}</span>
-                  )}
+                  {msg.role === 'user' && <span className={styles.avatar}>{userInitial}</span>}
                 </div>
-              ))}
+              ))
+            )}
           </div>
 
-          {/* Input bar */}
-          <div className={styles.inputBar}>
-            <button className={styles.attachBtn} aria-label="Attach file">
-              <Paperclip size={16} />
-            </button>
-            <input
-              className={styles.chatInput}
-              placeholder="Ask about culture, prep for interviews, or drag a company here..."
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-            />
-            <button
-              className={cn(
-                styles.sendBtn,
-                input.trim() && activeContext.length > 0 && !isStreaming && styles.sendBtnActive,
-              )}
-              onClick={handleSend}
-              disabled={!input.trim() || activeContext.length === 0 || isStreaming}
-              aria-label="Send message"
-            >
-              <Send size={16} />
-            </button>
+          <div className={styles.inputArea}>
+            {fileAlert && (
+              <div className={styles.fileAlert} role="alert" aria-live="polite">
+                {fileAlert}
+              </div>
+            )}
+
+            {selectedFile && (
+              <div className={styles.selectedFileRow}>
+                <div className={styles.selectedFileChip}>
+                  <FileText size={14} />
+                  <span className={styles.selectedFileName}>{selectedFile.name}</span>
+                </div>
+                <button
+                  type="button"
+                  className={styles.selectedFileRemove}
+                  onClick={handleRemoveSelectedFile}
+                  aria-label={`Remove ${selectedFile.name}`}
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            )}
+
+            <div className={styles.inputBar}>
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                className={styles.hiddenFileInput}
+                onChange={handleFileChange}
+              />
+
+              <button
+                type="button"
+                className={styles.attachBtn}
+                aria-label="Attach file"
+                onClick={handleAttachClick}
+              >
+                <Paperclip size={16} />
+              </button>
+
+              <input
+                className={styles.chatInput}
+                placeholder="Ask about culture, prep for interviews, or drag a company here..."
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+              />
+
+              <button
+                className={cn(
+                  styles.sendBtn,
+                  input.trim() && activeContext.length > 0 && !isStreaming && styles.sendBtnActive,
+                )}
+                onClick={handleSend}
+                disabled={!input.trim() || activeContext.length === 0 || isStreaming}
+                aria-label="Send message"
+              >
+                <Send size={16} />
+              </button>
+            </div>
           </div>
         </div>
       </div>
-
-      <AddCompanyModal 
-        isOpen={isAddModalOpen} 
-        onClose={() => setIsAddModalOpen(false)}
-        initialCompanyName={searchQuery}
-        onSuccess={async (_newId, newName) => {
-          setIsAddModalOpen(false);
-          setSearchQuery(newName);
-          await refreshCompanies();
-          setToastConfig({ message: `Added ${newName} to your board!`, variant: 'success' })
-        }}
-      />
-      <ConfirmModal
-        isOpen={!!companyToDelete}
-        title="Delete Company"
-        message={`Are you sure you want to remove "${companyToDelete?.name}" from your board? This action cannot be undone.`}
-        confirmText="Delete"
-        onCancel={() => setCompanyToDelete(null)}
-        onConfirm={handleDeleteCompany}
-      />
-      {/* Toast Component */}
-      {toastConfig && (
-        <StandardToast 
-          message={toastConfig.message} 
-          variant={toastConfig.variant} 
-          onDone={() => setToastConfig(null)} 
-        />
-      )}
     </div>
   )
 }

--- a/apps/web/src/pages/ResumePage.tsx
+++ b/apps/web/src/pages/ResumePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, KeyboardEvent, useCallback } from 'react'
 import html2pdf from 'html2pdf.js'
-import { Download, Sparkles, Search, X, Plus, FileUp } from 'lucide-react'
+import { Download, Sparkles, Search, X, Plus, FileUp, FileText } from 'lucide-react'
 import { Button } from '@/components/ui'
 import { XpToast } from '@/components/interview/XpToast'
 import { ResumeSuggestionsPanel } from '@/components/resume/ResumeSuggestionsPanel'
@@ -39,13 +39,13 @@ import {
   getResumeToastTitle,
   type ResumeGamificationEventType,
 } from '@/lib/gamification'
-import type { ResumeDocument, ResumeTailorEdit } from '@/types'
+import type { ResumeDocument, ResumeTailorEdit, ResumeRecordDto } from '@/types'
 import { cn } from '@/utils/cn'
 import styles from './ResumePage.module.css'
 
 // Helper: Extract and trim text from contentEditable element
 const readEditableText = (element: HTMLElement): string => {
-  return (element?.textContent?.trim() || '')
+  return element?.textContent?.trim() || ''
 }
 
 const MOCK_RESUME = {
@@ -123,26 +123,36 @@ const toInitialResumeContent = (): ResumeDocument => ({
   ],
 })
 
+const formatResumeDate = (value: string | null | undefined) => {
+  if (!value) return 'No date'
+  return new Date(value).toLocaleDateString()
+}
+
 export default function ResumePage() {
   const { user } = useAuth()
   const resumeRef = useRef<HTMLDivElement>(null)
   const [activeTargetId, setActiveTargetId] = useState<string | null>(null)
   const [resumeContent, setResumeContent] = useState<ResumeDocument>(toInitialResumeContent())
+  const [savedResumes, setSavedResumes] = useState<ResumeRecordDto[]>([])
   const [jobDescription, setJobDescription] = useState('')
   const [skillInput, setSkillInput] = useState('')
   const [pendingEdits, setPendingEdits] = useState<ResumeTailorEdit[]>([])
   const [tailorRunState, setTailorRunState] = useState<'idle' | 'complete'>('idle')
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [isPreviewMode, setIsPreviewMode] = useState(false)
+  const [isExportingPDF, setIsExportingPDF] = useState(false)
   const [activeResumeId, setActiveResumeId] = useState<string | null>(null)
+
   const { runTailor, isLoading, error: tailorError, clearError } = useResumeTailor()
   const {
     loadPrimaryResume,
+    loadUserResumes,
     saveResume,
     isLoading: isPersistenceLoading,
     error: persistenceError,
     clearError: clearPersistenceError,
   } = useResumePersistence()
+
   const {
     uploadAndParse,
     phase: uploadPhase,
@@ -190,6 +200,25 @@ export default function ResumePage() {
     [user?.id, pushGamificationToast],
   )
 
+  const loadSavedResumes = useCallback(async () => {
+    if (!user?.id) return
+
+    try {
+      const resumes = await loadUserResumes(user.id)
+      setSavedResumes(resumes ?? [])
+    } catch {
+      // surfaced through persistenceError
+    }
+  }, [user?.id, loadUserResumes])
+
+  const handleLoadResume = useCallback((resume: ResumeRecordDto) => {
+    if (!resume.structuredContent) return
+    setResumeContent(normalizeResumeDocument(resume.structuredContent))
+    setActiveResumeId(resume.id)
+    setPendingEdits([])
+    setSubmitError(null)
+  }, [])
+
   // ── Local helpers for contentEditable field updates ──
   const handleUpdateProfileField = (field: 'name' | 'contact', text: string) => {
     setResumeContent((prev) => updateProfileField(prev, field, text))
@@ -219,12 +248,21 @@ export default function ResumePage() {
       clearPersistenceError()
 
       try {
-        const existing = await loadPrimaryResume(user.id)
-        if (cancelled || !existing?.structuredContent) return
-        setResumeContent(normalizeResumeDocument(existing.structuredContent))
-        setActiveResumeId(existing.id)
+        const [existing, resumes] = await Promise.all([
+          loadPrimaryResume(user.id),
+          loadUserResumes(user.id),
+        ])
+
+        if (cancelled) return
+
+        if (existing?.structuredContent) {
+          setResumeContent(normalizeResumeDocument(existing.structuredContent))
+          setActiveResumeId(existing.id)
+        }
+
+        setSavedResumes(resumes ?? [])
       } catch {
-        // error surfaced through persistenceError
+        // surfaced through persistenceError
       }
     }
 
@@ -233,7 +271,7 @@ export default function ResumePage() {
     return () => {
       cancelled = true
     }
-  }, [user?.id, loadPrimaryResume, clearPersistenceError])
+  }, [user?.id, loadPrimaryResume, loadUserResumes, clearPersistenceError])
 
   async function handlePdfImport(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
@@ -266,6 +304,7 @@ export default function ResumePage() {
           ? 'Resume imported with partial parsing. Please review and edit extracted sections.'
           : null
       )
+      await loadSavedResumes()
     } else {
       setSubmitError(`Could not parse "${file.name}". Please try a different file.`)
     }
@@ -353,16 +392,31 @@ export default function ResumePage() {
 
   async function handleExportPDF() {
     if (!resumeRef.current) return
-    await html2pdf()
-      .set({
-        margin: [10, 10, 10, 10],
-        filename: 'resume_export.pdf',
-        image: { type: 'jpeg', quality: 0.98 },
-        html2canvas: { scale: 2, useCORS: true },
-        jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
+
+    try {
+      setIsExportingPDF(true)
+
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve())
       })
-      .from(resumeRef.current)
-      .save()
+
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve())
+      })
+
+      await html2pdf()
+        .set({
+          margin: [10, 10, 10, 10],
+          filename: 'resume_export.pdf',
+          image: { type: 'jpeg', quality: 0.98 },
+          html2canvas: { scale: 2, useCORS: true },
+          jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
+        })
+        .from(resumeRef.current)
+        .save()
+    } finally {
+      setIsExportingPDF(false)
+    }
   }
 
   async function handleSaveResume() {
@@ -376,12 +430,13 @@ export default function ResumePage() {
 
     try {
       await saveResume(activeResumeId, resumeContent, 'edited')
+      await loadSavedResumes()
     } catch {
-      // error surfaced through persistenceError
+      // surfaced through persistenceError
     }
   }
 
-  const editable = !isPreviewMode
+  const editable = !isPreviewMode && !isExportingPDF
   const suggestionItems: ResumeSuggestionViewModel[] = buildResumeSuggestionViewModels(resumeContent, pendingEdits)
   const suggestionPanelState = tailorRunState === 'idle' ? 'idle' : tailorRunState
   const pageError = submitError ?? uploadError ?? persistenceError ?? tailorError
@@ -425,6 +480,7 @@ export default function ResumePage() {
           onDone={() => setGamificationToasts((prev) => prev.filter((x) => x.id !== t.id))}
         />
       ))}
+
       <div className={styles.header}>
         <div>
           <h1 className={styles.title}>Resume Editor</h1>
@@ -455,12 +511,13 @@ export default function ResumePage() {
             onChange={handlePdfImport}
           />
           <Button
-            variant='secondary'
-            size='sm'
+            variant="secondary"
+            size="sm"
             onClick={() => pdfInputRef.current?.click()}
             loading={isUploadLoading}
           >
-            <FileUp size={14} /> {uploadPhase === 'uploading' || uploadPhase === 'parsing' ? 'Processing...' : 'Upload Resume'}
+            <FileUp size={14} />{' '}
+            {uploadPhase === 'uploading' || uploadPhase === 'parsing' ? 'Processing...' : 'Upload Resume'}
           </Button>
           <Button variant="secondary" size="sm" onClick={handleExportPDF}>
             <Download size={14} />
@@ -477,6 +534,89 @@ export default function ResumePage() {
       </div>
 
       <div className={styles.layout}>
+        <aside
+          style={{
+            width: '240px',
+            flexShrink: 0,
+            border: '1px solid var(--color-border)',
+            borderRadius: '16px',
+            background: 'var(--color-bg)',
+            padding: '16px',
+            height: 'fit-content',
+            maxHeight: 'calc(100vh - 180px)',
+            overflowY: 'auto',
+          }}
+        >
+          <h3
+            style={{
+              margin: '0 0 12px 0',
+              fontSize: '14px',
+              fontWeight: 700,
+              color: 'var(--color-text)',
+            }}
+          >
+            Saved Resumes
+          </h3>
+
+          {savedResumes.length === 0 ? (
+            <p
+              style={{
+                margin: 0,
+                fontSize: '13px',
+                color: 'var(--color-text-secondary)',
+              }}
+            >
+              No saved resumes yet.
+            </p>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+              {savedResumes.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => handleLoadResume(item)}
+                  style={{
+                    width: '100%',
+                    textAlign: 'left',
+                    border: activeResumeId === item.id
+                      ? '1px solid var(--color-primary)'
+                      : '1px solid var(--color-border)',
+                    background: activeResumeId === item.id
+                      ? 'var(--color-primary-subtle)'
+                      : 'transparent',
+                    borderRadius: '12px',
+                    padding: '10px 12px',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '8px',
+                      marginBottom: '6px',
+                      color: 'var(--color-text)',
+                      fontSize: '13px',
+                      fontWeight: 600,
+                    }}
+                  >
+                    <FileText size={14} />
+                    <span>{item.title || item.fileName || 'Untitled Resume'}</span>
+                  </div>
+                  <div
+                    style={{
+                      fontSize: '12px',
+                      color: 'var(--color-text-secondary)',
+                    }}
+                  >
+                    Updated {formatResumeDate(item.updatedAt ?? item.createdAt)}
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </aside>
+
         <aside className={styles.leftPanel}>
           <div className={styles.card}>
             <p className={styles.cardTitle}>Target Job Description</p>


### PR DESCRIPTION
# Summary
Adds a Saved Resumes section to the Resume page so users can view and load previously uploaded or tailored resumes.

# Changes
- added repository support for fetching all resumes for a user
- extended resume persistence hook to load saved resumes
- added Saved Resumes sidebar on the Resume page
- enabled clicking a saved resume to load it into the editor
- refreshed saved resumes list after upload and save actions

# Testing
- verified saved resumes are displayed on the Resume page
- verified clicking a saved resume loads it into the editor
- verified uploading a resume updates the saved list
- verified saving a resume refreshes the list

# Future Improvement
- add delete functionality for saved resumes to manage long lists