### PR TITLE
Fix bar chart height rendering in Practice Consistency card

### DIFF
--- a/apps/web/src/pages/DashboardPage.module.css
+++ b/apps/web/src/pages/DashboardPage.module.css
@@ -189,6 +189,10 @@
   transition: height 0.3s;
 }
 
+.barActive {
+  background-color: var(--color-primary);
+}
+
 .barToday {
   background-color: var(--color-text);
 }

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -111,11 +111,11 @@ function PracticeConsistencyCard({
 
         <div className={styles.barChart}>
           {labels.map((label, i) => {
-            const heightPct = `${Math.max((buckets[i] / maxMinutes) * 100, 4)}%`
+            const heightPx = Math.max((buckets[i] / maxMinutes) * 80, 4)
 
             return (
               <div key={`bucket-${i}`} className={styles.barGroup}>
-                <div className={styles.bar} style={{ height: heightPct }} />
+                <div className={styles.bar} style={{ height: heightPx }} />
                 <span className={styles.barLabel}>{label}</span>
               </div>
             )

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import { Badge, Spinner } from '@/components/ui'
 import { GamificationCard } from '@/components/dashboard/GamificationCard'
 import { useDashboardData } from '@/hooks/useDashboardData'
+import { formatMinutes } from '@/utils/formatMinutes'
 import { cn } from '@/utils/cn'
 import type {
   ResearchSessionSummary,
@@ -112,10 +113,14 @@ function PracticeConsistencyCard({
         <div className={styles.barChart}>
           {labels.map((label, i) => {
             const heightPx = Math.max((buckets[i] / maxMinutes) * 80, 4)
+            const tooltip = buckets[i] === 0 ? 'No activity' : formatMinutes(buckets[i])
 
             return (
-              <div key={`bucket-${i}`} className={styles.barGroup}>
-                <div className={styles.bar} style={{ height: heightPx }} />
+              <div key={`bucket-${i}`} className={styles.barGroup} data-tooltip={tooltip}>
+                <div
+                  className={cn(styles.bar, buckets[i] > 0 && styles.barActive)}
+                  style={{ height: heightPx }}
+                />
                 <span className={styles.barLabel}>{label}</span>
               </div>
             )


### PR DESCRIPTION
## Summary
- Bar heights were using `height: X%` but `.barGroup` has no explicit height, so percentage resolved to zero — all bars appeared flat
- Switch to pixel values (`height: Xpx`, max 80px) matching the original implementation

## Test plan
- [ ] Dashboard Practice Consistency card shows bars at varying heights based on activity
- [ ] The tallest bar reaches ~80px; inactive days show a small 4px baseline bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)