### PR TITLE
Revert bar chart color from blue to subtle gray

### DIFF
--- a/apps/web/src/pages/DashboardPage.module.css
+++ b/apps/web/src/pages/DashboardPage.module.css
@@ -184,13 +184,9 @@
 .bar {
   width: 100%;
   border-radius: var(--radius-sm) var(--radius-sm) 0 0;
-  background-color: var(--color-bg-muted);
+  background-color: var(--color-border);
   min-height: 4px;
   transition: height 0.3s;
-}
-
-.barActive {
-  background-color: var(--color-primary);
 }
 
 .barToday {

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -117,10 +117,7 @@ function PracticeConsistencyCard({
 
             return (
               <div key={`bucket-${i}`} className={styles.barGroup} data-tooltip={tooltip}>
-                <div
-                  className={cn(styles.bar, buckets[i] > 0 && styles.barActive)}
-                  style={{ height: heightPx }}
-                />
+                <div className={styles.bar} style={{ height: heightPx }} />
                 <span className={styles.barLabel}>{label}</span>
               </div>
             )


### PR DESCRIPTION
## Summary
- Blue (`--color-primary`) was too dominant for the bar chart
- Revert to subtle gray using `--color-border` (#e5e7eb) — one shade darker than the original `--color-bg-muted` so bars are actually visible against the white card background

🤖 Generated with [Claude Code](https://claude.com/claude-code)