### PR TITLE
Fix research context lost on navigation and empty dashboard sessions

### DIFF
--- a/apps/web/src/hooks/useResearchChat.ts
+++ b/apps/web/src/hooks/useResearchChat.ts
@@ -84,6 +84,7 @@ export function useResearchChat({
   const sessionIdRef = useRef<string | null>(null)
   const sessionAttachmentRef = useRef<AttachmentPayload | null>(null)
   const loadedRoleRef = useRef<string | null>(null)
+  const loadedCompanyRef = useRef<string | null>(null)
 
   // Load existing research session for this role
   useEffect(() => {
@@ -116,12 +117,45 @@ export function useResearchChat({
       })
   }, [user, roleId])
 
+  // Load existing research session for a company when no role is selected
+  useEffect(() => {
+    if (!user || !companyProfileId || roleId) return
+    if (loadedCompanyRef.current === companyProfileId) return
+    loadedCompanyRef.current = companyProfileId
+
+    supabase
+      .from('research_sessions')
+      .select('id, messages')
+      .eq('user_id', user.id)
+      .eq('company_profile_id', companyProfileId)
+      .is('company_role_id', null)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .then(({ data, error }) => {
+        if (error || !data || data.length === 0) return
+        const row = data[0]
+        const saved = row.messages as Array<{ role: string; content: string; timestamp: string }>
+        if (!saved || saved.length === 0) return
+
+        sessionIdRef.current = row.id as string
+        setSessionId(row.id as string)
+        setMessages(
+          saved.map((m, i) => ({
+            id: `saved-${i}`,
+            role: m.role as 'user' | 'assistant',
+            content: m.content,
+            timestamp: new Date(m.timestamp),
+          }))
+        )
+      })
+  }, [user, companyProfileId, roleId])
+
   // Persist messages to research_sessions after streaming completes
   const persistMessages = useCallback(
     async (allMessages: Message[]) => {
       if (!user) return
-      // Only persist if we have a role context
-      if (!roleId) return
+      // Only persist if we have at least a company or role context
+      if (!companyProfileId && !roleId) return
 
       const rows = allMessages
         .filter((m) => m.id !== 'init')
@@ -168,6 +202,7 @@ export function useResearchChat({
     sessionIdRef.current = null
     setSessionId(null)
     loadedRoleRef.current = null
+    loadedCompanyRef.current = null
   }, [])
 
   const sendMessage = useCallback(

--- a/apps/web/src/pages/ResearchPage.tsx
+++ b/apps/web/src/pages/ResearchPage.tsx
@@ -64,6 +64,7 @@ export default function ResearchPage() {
   const [searchQuery, setSearchQuery] = useState(() => {
     return location.state?.companyName || '';
   });
+  const CONTEXT_KEY = 'research_active_context'
   const [activeContext, setActiveContext] = useState<ActiveContextItem[]>([])
   const [input, setInput] = useState('')
   const [attachment, setAttachment] = useState<{ name: string; excerpt: string } | null>(null)
@@ -118,6 +119,32 @@ export default function ResearchPage() {
       }
     }
   }, [location.state, dbCompanies, navigate, location.pathname, searchQuery])
+
+  // Persist active context chips across navigation
+  useEffect(() => {
+    if (activeContext.length > 0) {
+      sessionStorage.setItem(CONTEXT_KEY, JSON.stringify(activeContext))
+    } else {
+      sessionStorage.removeItem(CONTEXT_KEY)
+    }
+  }, [activeContext])
+
+  // Restore active context on mount once DB companies are loaded
+  const restoredContextRef = useRef(false)
+  useEffect(() => {
+    if (restoredContextRef.current || dbCompanies.length === 0) return
+    restoredContextRef.current = true
+    const raw = sessionStorage.getItem(CONTEXT_KEY)
+    if (!raw) return
+    try {
+      const saved = JSON.parse(raw) as ActiveContextItem[]
+      const valid = saved.filter((item) => dbCompanies.some((c) => c.id === item.company.id))
+      if (valid.length > 0) setActiveContext(valid)
+    } catch {
+      // ignore malformed data
+    }
+  }, [dbCompanies])
+
   const userInitial = user?.email?.[0].toUpperCase() ?? '?'
 
   // Derive active context for the chat hook
@@ -185,6 +212,7 @@ export default function ResearchPage() {
     setInput('')
     setAttachment(null)
     setAttachmentError(null)
+    sessionStorage.removeItem(CONTEXT_KEY)
   }
 
   async function handleAttachmentChange(e: React.ChangeEvent<HTMLInputElement>) {


### PR DESCRIPTION
## Summary
- **Context lost on nav**: Research page now saves the active company chips to `sessionStorage` and restores them when you come back. Matches were validated against current DB data so stale entries are silently dropped.
- **Dashboard Recent Research empty**: `persistMessages` previously bailed out unless a role was selected. Now saves whenever a `companyProfileId` is present — so company-only sessions hit the DB and show up on the dashboard.
- **Bonus**: Added a load-by-company effect so if you return to the same company (without a role), prior messages reload from the DB.

## Test plan
- [ ] Drag a company into context, send a message, navigate to Dashboard, come back — context chips and messages are restored
- [ ] Dashboard "Recent Research" shows sessions after doing research (even without selecting a specific role)
- [ ] "New board" clears both the chips and sessionStorage (fresh start)
- [ ] Selecting a role still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)