### PR TITLE
Dashboard recent research links + logos, fix context restore

### DIFF
--- a/apps/web/src/hooks/useDashboardData.ts
+++ b/apps/web/src/hooks/useDashboardData.ts
@@ -25,7 +25,9 @@ interface RawResearchSession {
   id: string
   title: string | null
   created_at: string
-  company_profiles: { company_name: string; industry: string | null } | null
+  company_profile_id: string | null
+  company_role_id: string | null
+  company_profiles: { company_name: string; industry: string | null; company_website: string | null } | null
 }
 
 interface RawPracticeSession {
@@ -253,7 +255,7 @@ export function useDashboardData({
         const [sessionsRes, companiesRes] = await Promise.all([
           supabase
             .from('research_sessions')
-            .select('id, title, created_at, company_profiles(company_name, industry)')
+            .select('id, title, created_at, company_profile_id, company_role_id, company_profiles(company_name, industry, company_website)')
             .eq('user_id', userId)
             .order('created_at', { ascending: false })
             .limit(3)
@@ -277,6 +279,9 @@ export function useDashboardData({
           createdAt: row.created_at,
           companyName: row.company_profiles?.company_name ?? null,
           industry: row.company_profiles?.industry ?? null,
+          companyProfileId: row.company_profile_id ?? null,
+          companyRoleId: row.company_role_id ?? null,
+          companyWebsite: row.company_profiles?.company_website ?? null,
         })))
 
         setCompanies((companiesRes.data ?? []).map((row) => ({

--- a/apps/web/src/pages/DashboardPage.module.css
+++ b/apps/web/src/pages/DashboardPage.module.css
@@ -269,6 +269,25 @@
   display: flex;
   align-items: center;
   gap: var(--space-3);
+  text-decoration: none;
+  color: inherit;
+  border-radius: var(--radius-md);
+  transition: background-color 0.15s;
+  margin: calc(-1 * var(--space-1));
+  padding: var(--space-1);
+}
+
+.itemRow:hover {
+  background-color: var(--color-bg-subtle);
+}
+
+.sessionLogo {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-md);
+  object-fit: contain;
+  flex-shrink: 0;
+  border: 1px solid var(--color-border);
 }
 
 .iconBox {

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -128,6 +128,25 @@ function PracticeConsistencyCard({
   )
 }
 
+function SessionLogo({ companyWebsite, companyName }: { companyWebsite: string | null; companyName: string | null }): JSX.Element {
+  const [hasError, setHasError] = useState(false)
+  if (companyWebsite && !hasError) {
+    return (
+      <img
+        src={`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/company-logo?domain=${encodeURIComponent(companyWebsite)}`}
+        alt={companyName ?? ''}
+        className={styles.sessionLogo}
+        onError={() => setHasError(true)}
+      />
+    )
+  }
+  return (
+    <div className={styles.iconBox}>
+      <Building2 size={16} />
+    </div>
+  )
+}
+
 function RecentResearchCard({ sessions }: RecentResearchCardProps): JSX.Element {
   return (
     <div className={styles.card}>
@@ -150,21 +169,25 @@ function RecentResearchCard({ sessions }: RecentResearchCardProps): JSX.Element 
         ) : (
           <ul className={styles.itemList}>
             {sessions.map((session) => (
-              <li key={session.id} className={styles.itemRow}>
-                <div className={styles.iconBox}>
-                  <Building2 size={16} />
-                </div>
-                <div className={styles.itemInfo}>
-                  <p className={styles.itemTitle}>{session.title ?? 'Research session'}</p>
-                  <p className={styles.itemSub}>{session.companyName ?? '—'}</p>
-                </div>
-                <div className={styles.itemMeta}>
-                  {session.industry && <Badge>{session.industry}</Badge>}
-                  <span className={styles.timeStamp}>
-                    <Calendar size={12} />
-                    {formatTimeAgo(session.createdAt)}
-                  </span>
-                </div>
+              <li key={session.id}>
+                <Link
+                  to="/research"
+                  state={{ companyProfileId: session.companyProfileId, roleId: session.companyRoleId }}
+                  className={styles.itemRow}
+                >
+                  <SessionLogo companyWebsite={session.companyWebsite} companyName={session.companyName} />
+                  <div className={styles.itemInfo}>
+                    <p className={styles.itemTitle}>{session.title ?? 'Research session'}</p>
+                    <p className={styles.itemSub}>{session.companyName ?? '—'}</p>
+                  </div>
+                  <div className={styles.itemMeta}>
+                    {session.industry && <Badge>{session.industry}</Badge>}
+                    <span className={styles.timeStamp}>
+                      <Calendar size={12} />
+                      {formatTimeAgo(session.createdAt)}
+                    </span>
+                  </div>
+                </Link>
               </li>
             ))}
           </ul>

--- a/apps/web/src/pages/ResearchPage.tsx
+++ b/apps/web/src/pages/ResearchPage.tsx
@@ -91,22 +91,26 @@ export default function ResearchPage() {
   const [newRoleJd, setNewRoleJd] = useState('')
   const roleInputRef = useRef<HTMLInputElement>(null)
 
-  // Auto-expand and select role from location state (e.g., coming back from interview)
+  // Set context from location state (dashboard links or interview back-nav).
+  // Role-based: waits for roles to load. Company-only: fires as soon as dbCompanies loads.
   const appliedLocationState = useRef(false)
   useEffect(() => {
     if (appliedLocationState.current) return
     const state = location.state as { companyProfileId?: string; roleId?: string } | null
-    if (state?.roleId && roles.length > 0) {
+    if (!state?.companyProfileId || dbCompanies.length === 0) return
+
+    if (state.roleId) {
+      if (roles.length === 0) return
       appliedLocationState.current = true
+      const company = dbCompanies.find((c) => c.id === state.companyProfileId)
       const role = roles.find((r) => r.id === state.roleId)
-      if (role && dbCompanies.length > 0) {
-        const company = dbCompanies.find((c) => c.id === state.companyProfileId)
-        if (company && !activeContext.find((ctx) => ctx.role?.id === role.id)) {
-          setActiveContext((prev) => [...prev, { company, role }])
-        }
-      }
+      if (company && role) setActiveContext([{ company, role }])
+    } else {
+      appliedLocationState.current = true
+      const company = dbCompanies.find((c) => c.id === state.companyProfileId)
+      if (company) setActiveContext([{ company }])
     }
-  }, [location.state, roles, dbCompanies, activeContext])
+  }, [location.state, roles, dbCompanies])
 
   useEffect(() => {
     if (location.state?.newCompanyId && dbCompanies.length > 0) {
@@ -120,8 +124,12 @@ export default function ResearchPage() {
     }
   }, [location.state, dbCompanies, navigate, location.pathname, searchQuery])
 
-  // Persist active context chips across navigation
+  // Persist active context chips to sessionStorage.
+  // Guard prevents clearing storage on the initial empty render before restore runs.
+  const hasSavedContextRef = useRef(false)
   useEffect(() => {
+    if (!hasSavedContextRef.current && activeContext.length === 0) return
+    hasSavedContextRef.current = true
     if (activeContext.length > 0) {
       sessionStorage.setItem(CONTEXT_KEY, JSON.stringify(activeContext))
     } else {
@@ -129,11 +137,15 @@ export default function ResearchPage() {
     }
   }, [activeContext])
 
-  // Restore active context on mount once DB companies are loaded
+  // Restore active context from sessionStorage on mount once DB companies load.
+  // Skipped when navigating via a location.state link (that effect sets context instead).
   const restoredContextRef = useRef(false)
   useEffect(() => {
     if (restoredContextRef.current || dbCompanies.length === 0) return
     restoredContextRef.current = true
+    hasSavedContextRef.current = true
+    const state = location.state as { companyProfileId?: string } | null
+    if (state?.companyProfileId) return  // location state effect handles this
     const raw = sessionStorage.getItem(CONTEXT_KEY)
     if (!raw) return
     try {
@@ -143,7 +155,7 @@ export default function ResearchPage() {
     } catch {
       // ignore malformed data
     }
-  }, [dbCompanies])
+  }, [dbCompanies, location.state])
 
   const userInitial = user?.email?.[0].toUpperCase() ?? '?'
 

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -95,6 +95,9 @@ export interface ResearchSessionSummary {
   createdAt: string
   companyName: string | null
   industry: string | null
+  companyProfileId: string | null
+  companyRoleId: string | null
+  companyWebsite: string | null
 }
 
 export interface CompanySummary {


### PR DESCRIPTION
## Summary

**Dashboard Recent Research:**
- Each session is now a clickable link → navigates to `/research` with `companyProfileId` + `roleId` in location state, restoring that specific session's context
- Company logos shown (same Supabase logo function as the Research tab), with a building icon fallback
- Hover state on rows

**Research page context restore:**
- **Bug fix**: The sessionStorage save effect was running on the initial empty render and immediately clearing the saved context before the restore effect had a chance to read it. A `hasSavedContextRef` guard prevents this.
- **Dashboard links**: Clicking a company-only session (no role) from the dashboard now correctly adds that company to the context bar
- **Skip restore when navigating via link**: If you arrive at Research via a dashboard link, the location.state effect sets the right context and sessionStorage restore is skipped to avoid conflicts

## Test plan
- [ ] Dashboard recent research sessions show company logos
- [ ] Clicking a session navigates to Research with the company/role in the context bar
- [ ] Navigating away from Research and back restores the company chips automatically (no manual drag needed)
- [ ] "New board" still clears everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)