### PR TITLE
Application pipeline

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,6 +9,7 @@ import DashboardPage from '@/pages/DashboardPage'
 import InterviewPage from '@/pages/InterviewPage'
 import ResearchPage from '@/pages/ResearchPage'
 import ResumePage from '@/pages/ResumePage'
+import PipelinePage from '@/pages/PipelinePage'
 
 export default function App() {
   return (
@@ -30,6 +31,7 @@ export default function App() {
             <Route path="interview" element={<InterviewPage />} />
             <Route path="research" element={<ResearchPage />} />
             <Route path="resume" element={<ResumePage />} />
+            <Route path="applications" element={<PipelinePage />} />
           </Route>
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -9,6 +9,7 @@ const NAV_LINKS = [
   { to: '/research', label: 'Research' },
   { to: '/resume', label: 'Resume' },
   { to: '/interview', label: 'Practice' },
+  { to: '/applications', label: 'Applications' },
 ]
 
 export default function AppShell() {

--- a/apps/web/src/components/ProtectedRoute.tsx
+++ b/apps/web/src/components/ProtectedRoute.tsx
@@ -7,7 +7,7 @@ export default function ProtectedRoute({ children }: { children: ReactNode }) {
 
   if (loading) return null
 
-  if (!session) return <Navigate to="/login" replace />
+  // if (!session) return <Navigate to="/login" replace />
 
   return <>{children}</>
 }

--- a/apps/web/src/components/ProtectedRoute.tsx
+++ b/apps/web/src/components/ProtectedRoute.tsx
@@ -7,7 +7,7 @@ export default function ProtectedRoute({ children }: { children: ReactNode }) {
 
   if (loading) return null
 
-  // if (!session) return <Navigate to="/login" replace />
+  if (!session) return <Navigate to="/login" replace />
 
   return <>{children}</>
 }

--- a/apps/web/src/pages/DashboardPage.module.css
+++ b/apps/web/src/pages/DashboardPage.module.css
@@ -391,7 +391,6 @@
 .pipelineStats {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: var(--space-4);
   margin-bottom: var(--space-4);
 }
 
@@ -399,6 +398,12 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
+  padding: var(--space-2) var(--space-4) var(--space-2) 0;
+}
+
+.pipelineStat:not(:first-child) {
+  padding-left: var(--space-4);
+  border-left: 1px solid var(--color-border);
 }
 
 .pipelineLabel {
@@ -409,7 +414,19 @@
 .pipelineValue {
   font-size: var(--font-2xl);
   font-weight: 700;
-  color: var(--color-text);
+  line-height: 1.1;
+}
+
+.pipelineValueApplied {
+  color: #3b82f6;
+}
+
+.pipelineValueInterviews {
+  color: #f59e0b;
+}
+
+.pipelineValueOffers {
+  color: #10b981;
 }
 
 .progressTrack {
@@ -430,11 +447,11 @@
 }
 
 .progressLayerMid {
-  background-color: var(--color-border-strong);
+  background-color: #f59e0b;
 }
 
 .progressLayerTop {
-  background-color: var(--color-text);
+  background-color: #10b981;
 }
 
 .pipelineFooter {

--- a/apps/web/src/pages/DashboardPage.module.css
+++ b/apps/web/src/pages/DashboardPage.module.css
@@ -418,6 +418,26 @@
   background-color: var(--color-text);
 }
 
+.pipelineFooter {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: var(--space-3);
+}
+
+.pipelineManageLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--font-xs);
+  color: var(--color-text-tertiary);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.pipelineManageLink:hover {
+  color: var(--color-text);
+}
+
 .emptyState {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -277,15 +277,15 @@ function ApplicationPipelineCard({
             <div className={styles.pipelineStats}>
               <div className={styles.pipelineStat}>
                 <span className={styles.pipelineLabel}>Applied</span>
-                <span className={styles.pipelineValue}>{pipeline.total}</span>
+                <span className={cn(styles.pipelineValue, styles.pipelineValueApplied)}>{pipeline.total}</span>
               </div>
               <div className={styles.pipelineStat}>
                 <span className={styles.pipelineLabel}>Interviews</span>
-                <span className={styles.pipelineValue}>{pipeline.interviews}</span>
+                <span className={cn(styles.pipelineValue, styles.pipelineValueInterviews)}>{pipeline.interviews}</span>
               </div>
               <div className={styles.pipelineStat}>
                 <span className={styles.pipelineLabel}>Offers</span>
-                <span className={styles.pipelineValue}>{pipeline.offers}</span>
+                <span className={cn(styles.pipelineValue, styles.pipelineValueOffers)}>{pipeline.offers}</span>
               </div>
             </div>
 

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -245,15 +245,15 @@ function ApplicationPipelineCard({
                 ? 'No applications tracked this week'
                 : 'No applications tracked this month'}
             </p>
-            <Link to="/research" className={styles.emptyAction}>
-              Find companies to apply to
+            <Link to="/applications" className={styles.emptyAction}>
+              Start tracking applications
             </Link>
           </div>
         ) : (
           <>
             <div className={styles.pipelineStats}>
               <div className={styles.pipelineStat}>
-                <span className={styles.pipelineLabel}>Total</span>
+                <span className={styles.pipelineLabel}>Applied</span>
                 <span className={styles.pipelineValue}>{pipeline.total}</span>
               </div>
               <div className={styles.pipelineStat}>
@@ -275,6 +275,12 @@ function ApplicationPipelineCard({
                 className={cn(styles.progressLayer, styles.progressLayerTop)}
                 style={{ width: `${(pipeline.offers / pipeline.total) * 100}%` }}
               />
+            </div>
+
+            <div className={styles.pipelineFooter}>
+              <Link to="/applications" className={styles.pipelineManageLink}>
+                Manage in Applications <ChevronRight size={12} />
+              </Link>
             </div>
           </>
         )}

--- a/apps/web/src/pages/PipelinePage.module.css
+++ b/apps/web/src/pages/PipelinePage.module.css
@@ -1,0 +1,371 @@
+/* ── Page shell ─────────────────────────────────────────────────────────── */
+
+.page {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 60px - 4rem);
+  min-height: 480px;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: var(--space-6);
+  flex-shrink: 0;
+}
+
+.title {
+  font-size: var(--font-2xl);
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  font-size: var(--font-sm);
+  color: var(--color-text-secondary);
+  margin-top: 0.375rem;
+}
+
+.errorBanner {
+  background: var(--color-error-subtle);
+  color: var(--color-error);
+  font-size: var(--font-sm);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-4);
+  flex-shrink: 0;
+}
+
+.loadingState {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-tertiary);
+  font-size: var(--font-sm);
+}
+
+/* ── Board ───────────────────────────────────────────────────────────────── */
+
+.board {
+  display: flex;
+  gap: var(--space-4);
+  flex: 1;
+  overflow-x: auto;
+  padding-bottom: var(--space-4);
+}
+
+.column {
+  flex: 0 0 220px;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg-subtle);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  padding: var(--space-3);
+  min-height: 0;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+.columnOver {
+  border-color: var(--color-primary);
+  background: var(--color-primary-subtle);
+}
+
+.colHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-3);
+  padding: 0 var(--space-1);
+  flex-shrink: 0;
+}
+
+.colLabel {
+  font-size: var(--font-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary);
+}
+
+.colCount {
+  font-size: var(--font-xs);
+  font-weight: 600;
+  color: var(--color-text-tertiary);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 0 var(--space-2);
+  line-height: 1.6;
+}
+
+.cardList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  flex: 1;
+  overflow-y: auto;
+}
+
+.emptyCol {
+  border: 1.5px dashed var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4) var(--space-3);
+  text-align: center;
+  font-size: var(--font-xs);
+  color: var(--color-text-tertiary);
+}
+
+/* ── Card ────────────────────────────────────────────────────────────────── */
+
+.card {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3);
+  cursor: grab;
+  transition: box-shadow 0.15s, border-color 0.15s;
+}
+
+.card:active {
+  cursor: grabbing;
+}
+
+.card:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  border-color: var(--color-border-strong);
+}
+
+.cardTop {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin-bottom: var(--space-1);
+}
+
+.cardTitle {
+  font-size: var(--font-sm);
+  font-weight: 600;
+  color: var(--color-text);
+  line-height: 1.35;
+  flex: 1;
+  min-width: 0;
+}
+
+.cardDelete {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-tertiary);
+  padding: 0;
+  opacity: 0;
+  flex-shrink: 0;
+  transition: opacity 0.15s, background-color 0.15s, color 0.15s;
+}
+
+.card:hover .cardDelete {
+  opacity: 1;
+}
+
+.cardDelete:hover {
+  background: var(--color-error-subtle);
+  color: var(--color-error);
+}
+
+.cardCompany {
+  font-size: var(--font-xs);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-1);
+}
+
+.cardNotes {
+  font-size: var(--font-xs);
+  color: var(--color-text-tertiary);
+  line-height: 1.45;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  margin-bottom: var(--space-2);
+}
+
+.cardFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: var(--space-2);
+  gap: var(--space-2);
+}
+
+.cardDate {
+  font-size: var(--font-xs);
+  color: var(--color-text-tertiary);
+  flex-shrink: 0;
+}
+
+.cardActions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.cardLink {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-tertiary);
+  transition: color 0.15s, background-color 0.15s;
+}
+
+.cardLink:hover {
+  color: var(--color-primary);
+  background: var(--color-primary-subtle);
+}
+
+.statusSelect {
+  font-size: 0.6875rem;
+  font-family: inherit;
+  color: var(--color-text-secondary);
+  background: var(--color-bg-subtle);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 2px var(--space-1);
+  cursor: pointer;
+  max-width: 100px;
+  transition: border-color 0.15s;
+}
+
+.statusSelect:hover {
+  border-color: var(--color-border-strong);
+}
+
+/* ── Add modal ───────────────────────────────────────────────────────────── */
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  padding: var(--space-4);
+}
+
+.modal {
+  background: var(--color-bg);
+  border-radius: var(--radius-xl);
+  width: 100%;
+  max-width: 440px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.16);
+  display: flex;
+  flex-direction: column;
+  animation: fadeUp 0.18s ease-out;
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.modalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-5) var(--space-6);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.modalTitle {
+  font-size: var(--font-lg);
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: -0.01em;
+}
+
+.modalClose {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-md);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-tertiary);
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.modalClose:hover {
+  background: var(--color-bg-subtle);
+  color: var(--color-text);
+}
+
+.modalBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-5) var(--space-6);
+}
+
+.fieldLabel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-size: var(--font-sm);
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.required {
+  color: var(--color-error);
+}
+
+.fieldInput {
+  font-size: var(--font-sm);
+  font-family: inherit;
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  width: 100%;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  outline: none;
+}
+
+.fieldInput:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-subtle);
+}
+
+.fieldTextarea {
+  resize: vertical;
+  min-height: 80px;
+}
+
+.modalFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  padding: var(--space-4) var(--space-6);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-bg-subtle);
+  border-bottom-left-radius: var(--radius-xl);
+  border-bottom-right-radius: var(--radius-xl);
+}

--- a/apps/web/src/pages/PipelinePage.module.css
+++ b/apps/web/src/pages/PipelinePage.module.css
@@ -58,7 +58,8 @@
 }
 
 .column {
-  flex: 0 0 220px;
+  flex: 1;
+  min-width: 140px;
   display: flex;
   flex-direction: column;
   background: var(--color-bg-subtle);

--- a/apps/web/src/pages/PipelinePage.tsx
+++ b/apps/web/src/pages/PipelinePage.tsx
@@ -1,0 +1,355 @@
+import { useState, useEffect } from 'react'
+import { Plus, X, ExternalLink } from 'lucide-react'
+import { Button } from '@/components/ui'
+import { ConfirmModal } from '@/utils/ConfirmModal'
+import { useAuth } from '@/contexts/AuthContext'
+import { supabase } from '@/lib/supabase'
+import { cn } from '@/utils/cn'
+import styles from './PipelinePage.module.css'
+
+type ApplicationStatus =
+  | 'saved'
+  | 'applied'
+  | 'phone_screen'
+  | 'interviewing'
+  | 'offer'
+  | 'rejected'
+  | 'withdrawn'
+
+interface JobApplication {
+  id: string
+  jobTitle: string
+  companyName: string
+  jobUrl: string | null
+  notes: string | null
+  status: ApplicationStatus
+  appliedAt: string | null
+  createdAt: string
+}
+
+interface AddFormState {
+  jobTitle: string
+  companyName: string
+  jobUrl: string
+  notes: string
+  status: ApplicationStatus
+}
+
+const COLUMNS: { key: string; label: string; statuses: ApplicationStatus[] }[] = [
+  { key: 'saved', label: 'Saved', statuses: ['saved'] },
+  { key: 'applied', label: 'Applied', statuses: ['applied'] },
+  { key: 'phone_screen', label: 'Phone Screen', statuses: ['phone_screen'] },
+  { key: 'interviewing', label: 'Interviewing', statuses: ['interviewing'] },
+  { key: 'offer', label: 'Offer', statuses: ['offer'] },
+  { key: 'closed', label: 'Closed', statuses: ['rejected', 'withdrawn'] },
+]
+
+const STATUS_LABELS: Record<ApplicationStatus, string> = {
+  saved: 'Saved',
+  applied: 'Applied',
+  phone_screen: 'Phone Screen',
+  interviewing: 'Interviewing',
+  offer: 'Offer',
+  rejected: 'Rejected',
+  withdrawn: 'Withdrawn',
+}
+
+const ALL_STATUSES: ApplicationStatus[] = [
+  'saved', 'applied', 'phone_screen', 'interviewing', 'offer', 'rejected', 'withdrawn',
+]
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+export default function PipelinePage() {
+  const { user } = useAuth()
+  const [applications, setApplications] = useState<JobApplication[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showAddModal, setShowAddModal] = useState(false)
+  const [addForm, setAddForm] = useState<AddFormState>({
+    jobTitle: '', companyName: '', jobUrl: '', notes: '', status: 'saved',
+  })
+  const [isSaving, setIsSaving] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<JobApplication | null>(null)
+  const [dragId, setDragId] = useState<string | null>(null)
+  const [dragOverCol, setDragOverCol] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!user?.id) return
+    void loadApplications()
+  }, [user?.id])
+
+  async function loadApplications() {
+    setIsLoading(true)
+    setError(null)
+    const { data, error: err } = await supabase
+      .from('job_applications')
+      .select('id, job_title, company_name, job_url, notes, status, applied_at, created_at')
+      .eq('user_id', user!.id)
+      .order('created_at', { ascending: false })
+
+    if (err) {
+      setError('Failed to load applications.')
+    } else {
+      setApplications(
+        (data ?? []).map((row) => ({
+          id: row.id,
+          jobTitle: row.job_title,
+          companyName: row.company_name ?? '',
+          jobUrl: row.job_url,
+          notes: row.notes,
+          status: row.status as ApplicationStatus,
+          appliedAt: row.applied_at,
+          createdAt: row.created_at,
+        }))
+      )
+    }
+    setIsLoading(false)
+  }
+
+  async function handleAdd() {
+    if (!user?.id || !addForm.jobTitle.trim() || !addForm.companyName.trim()) return
+    setIsSaving(true)
+    const { data, error: err } = await supabase
+      .from('job_applications')
+      .insert({
+        user_id: user.id,
+        job_title: addForm.jobTitle.trim(),
+        company_name: addForm.companyName.trim(),
+        job_url: addForm.jobUrl.trim() || null,
+        notes: addForm.notes.trim() || null,
+        status: addForm.status,
+      })
+      .select('id, job_title, company_name, job_url, notes, status, applied_at, created_at')
+      .single()
+
+    if (!err && data) {
+      setApplications((prev) => [
+        {
+          id: data.id,
+          jobTitle: data.job_title,
+          companyName: data.company_name ?? '',
+          jobUrl: data.job_url,
+          notes: data.notes,
+          status: data.status as ApplicationStatus,
+          appliedAt: data.applied_at,
+          createdAt: data.created_at,
+        },
+        ...prev,
+      ])
+      setShowAddModal(false)
+      setAddForm({ jobTitle: '', companyName: '', jobUrl: '', notes: '', status: 'saved' })
+    }
+    setIsSaving(false)
+  }
+
+  async function handleStatusChange(id: string, status: ApplicationStatus) {
+    setApplications((prev) => prev.map((a) => (a.id === id ? { ...a, status } : a)))
+    await supabase.from('job_applications').update({ status }).eq('id', id)
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return
+    await supabase.from('job_applications').delete().eq('id', deleteTarget.id)
+    setApplications((prev) => prev.filter((a) => a.id !== deleteTarget.id))
+    setDeleteTarget(null)
+  }
+
+  function handleDragStart(id: string) {
+    setDragId(id)
+  }
+
+  function handleDrop(columnKey: string) {
+    if (!dragId) return
+    const col = COLUMNS.find((c) => c.key === columnKey)
+    if (!col) return
+    const targetStatus = col.statuses[0]
+    void handleStatusChange(dragId, targetStatus)
+    setDragId(null)
+    setDragOverCol(null)
+  }
+
+  const colApps = (col: typeof COLUMNS[number]) =>
+    applications.filter((a) => col.statuses.includes(a.status))
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.header}>
+        <div>
+          <h1 className={styles.title}>Applications</h1>
+          <p className={styles.subtitle}>Track your job applications from start to finish.</p>
+        </div>
+        <Button variant="primary" size="sm" onClick={() => setShowAddModal(true)}>
+          <Plus size={14} /> Add Application
+        </Button>
+      </div>
+
+      {error && <div className={styles.errorBanner}>{error}</div>}
+
+      {isLoading ? (
+        <div className={styles.loadingState}>Loading applications…</div>
+      ) : (
+        <div className={styles.board}>
+          {COLUMNS.map((col) => {
+            const cards = colApps(col)
+            const isOver = dragOverCol === col.key
+            return (
+              <div
+                key={col.key}
+                className={cn(styles.column, isOver && styles.columnOver)}
+                onDragOver={(e) => { e.preventDefault(); setDragOverCol(col.key) }}
+                onDragLeave={() => setDragOverCol(null)}
+                onDrop={() => handleDrop(col.key)}
+              >
+                <div className={styles.colHeader}>
+                  <span className={styles.colLabel}>{col.label}</span>
+                  <span className={styles.colCount}>{cards.length}</span>
+                </div>
+                <div className={styles.cardList}>
+                  {cards.length === 0 && (
+                    <div className={styles.emptyCol}>Drop here</div>
+                  )}
+                  {cards.map((app) => (
+                    <div
+                      key={app.id}
+                      className={styles.card}
+                      draggable
+                      onDragStart={() => handleDragStart(app.id)}
+                      onDragEnd={() => { setDragId(null); setDragOverCol(null) }}
+                    >
+                      <div className={styles.cardTop}>
+                        <p className={styles.cardTitle}>{app.jobTitle}</p>
+                        <button
+                          className={styles.cardDelete}
+                          onClick={() => setDeleteTarget(app)}
+                          aria-label="Delete application"
+                        >
+                          <X size={12} />
+                        </button>
+                      </div>
+                      <p className={styles.cardCompany}>{app.companyName}</p>
+                      {app.notes && <p className={styles.cardNotes}>{app.notes}</p>}
+                      <div className={styles.cardFooter}>
+                        <span className={styles.cardDate}>
+                          {formatDate(app.appliedAt ?? app.createdAt)}
+                        </span>
+                        <div className={styles.cardActions}>
+                          {app.jobUrl && (
+                            <a
+                              href={app.jobUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className={styles.cardLink}
+                              aria-label="Open job posting"
+                            >
+                              <ExternalLink size={12} />
+                            </a>
+                          )}
+                          <select
+                            className={styles.statusSelect}
+                            value={app.status}
+                            onChange={(e) => handleStatusChange(app.id, e.target.value as ApplicationStatus)}
+                          >
+                            {ALL_STATUSES.map((s) => (
+                              <option key={s} value={s}>{STATUS_LABELS[s]}</option>
+                            ))}
+                          </select>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Add application modal */}
+      {showAddModal && (
+        <div className={styles.modalOverlay} onClick={() => setShowAddModal(false)}>
+          <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.modalHeader}>
+              <h2 className={styles.modalTitle}>Add Application</h2>
+              <button className={styles.modalClose} onClick={() => setShowAddModal(false)} aria-label="Close">
+                <X size={16} />
+              </button>
+            </div>
+            <div className={styles.modalBody}>
+              <label className={styles.fieldLabel}>
+                <span>Job Title <span className={styles.required}>*</span></span>
+                <input
+                  className={styles.fieldInput}
+                  placeholder="e.g. Senior Frontend Engineer"
+                  value={addForm.jobTitle}
+                  onChange={(e) => setAddForm((f) => ({ ...f, jobTitle: e.target.value }))}
+                />
+              </label>
+              <label className={styles.fieldLabel}>
+                <span>Company <span className={styles.required}>*</span></span>
+                <input
+                  className={styles.fieldInput}
+                  placeholder="e.g. Stripe"
+                  value={addForm.companyName}
+                  onChange={(e) => setAddForm((f) => ({ ...f, companyName: e.target.value }))}
+                />
+              </label>
+              <label className={styles.fieldLabel}>
+                Job URL
+                <input
+                  className={styles.fieldInput}
+                  placeholder="https://..."
+                  value={addForm.jobUrl}
+                  onChange={(e) => setAddForm((f) => ({ ...f, jobUrl: e.target.value }))}
+                />
+              </label>
+              <label className={styles.fieldLabel}>
+                Status
+                <select
+                  className={styles.fieldInput}
+                  value={addForm.status}
+                  onChange={(e) => setAddForm((f) => ({ ...f, status: e.target.value as ApplicationStatus }))}
+                >
+                  {ALL_STATUSES.map((s) => (
+                    <option key={s} value={s}>{STATUS_LABELS[s]}</option>
+                  ))}
+                </select>
+              </label>
+              <label className={styles.fieldLabel}>
+                Notes
+                <textarea
+                  className={cn(styles.fieldInput, styles.fieldTextarea)}
+                  placeholder="Any notes about this role..."
+                  value={addForm.notes}
+                  onChange={(e) => setAddForm((f) => ({ ...f, notes: e.target.value }))}
+                />
+              </label>
+            </div>
+            <div className={styles.modalFooter}>
+              <Button variant="secondary" onClick={() => setShowAddModal(false)}>Cancel</Button>
+              <Button
+                variant="primary"
+                onClick={handleAdd}
+                loading={isSaving}
+                disabled={!addForm.jobTitle.trim() || !addForm.companyName.trim()}
+              >
+                Add
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <ConfirmModal
+        isOpen={!!deleteTarget}
+        title="Delete Application"
+        message={`Remove "${deleteTarget?.jobTitle}" at ${deleteTarget?.companyName} from your pipeline?`}
+        confirmText="Delete"
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/pages/PipelinePage.tsx
+++ b/apps/web/src/pages/PipelinePage.tsx
@@ -21,6 +21,7 @@ interface JobApplication {
   jobTitle: string
   companyName: string
   jobUrl: string | null
+  jobDescription: string | null
   notes: string | null
   status: ApplicationStatus
   appliedAt: string | null
@@ -31,6 +32,7 @@ interface AddFormState {
   jobTitle: string
   companyName: string
   jobUrl: string
+  jobDescription: string
   notes: string
   status: ApplicationStatus
 }
@@ -69,12 +71,12 @@ export default function PipelinePage() {
   const [error, setError] = useState<string | null>(null)
   const [showAddModal, setShowAddModal] = useState(false)
   const [addForm, setAddForm] = useState<AddFormState>({
-    jobTitle: '', companyName: '', jobUrl: '', notes: '', status: 'saved',
+    jobTitle: '', companyName: '', jobUrl: '', jobDescription: '', notes: '', status: 'saved',
   })
   const [isSaving, setIsSaving] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<JobApplication | null>(null)
   const [editTarget, setEditTarget] = useState<JobApplication | null>(null)
-  const [editForm, setEditForm] = useState<AddFormState>({ jobTitle: '', companyName: '', jobUrl: '', notes: '', status: 'saved' })
+  const [editForm, setEditForm] = useState<AddFormState>({ jobTitle: '', companyName: '', jobUrl: '', jobDescription: '', notes: '', status: 'saved' })
   const [isUpdating, setIsUpdating] = useState(false)
   const [dragId, setDragId] = useState<string | null>(null)
   const [dragOverCol, setDragOverCol] = useState<string | null>(null)
@@ -88,7 +90,7 @@ export default function PipelinePage() {
       setError(null)
       const { data, error: err } = await supabase
         .from('job_applications')
-        .select('id, job_title, company_name, job_url, notes, status, applied_at, created_at')
+        .select('id, job_title, company_name, job_url, job_description, notes, status, applied_at, created_at')
         .eq('user_id', userId)
         .order('created_at', { ascending: false })
 
@@ -101,6 +103,7 @@ export default function PipelinePage() {
             jobTitle: row.job_title,
             companyName: row.company_name ?? '',
             jobUrl: row.job_url,
+            jobDescription: row.job_description,
             notes: row.notes,
             status: row.status as ApplicationStatus,
             appliedAt: row.applied_at,
@@ -124,10 +127,11 @@ export default function PipelinePage() {
         job_title: addForm.jobTitle.trim(),
         company_name: addForm.companyName.trim(),
         job_url: addForm.jobUrl.trim() || null,
+        job_description: addForm.jobDescription.trim() || null,
         notes: addForm.notes.trim() || null,
         status: addForm.status,
       })
-      .select('id, job_title, company_name, job_url, notes, status, applied_at, created_at')
+      .select('id, job_title, company_name, job_url, job_description, notes, status, applied_at, created_at')
       .single()
 
     if (!err && data) {
@@ -137,6 +141,7 @@ export default function PipelinePage() {
           jobTitle: data.job_title,
           companyName: data.company_name ?? '',
           jobUrl: data.job_url,
+          jobDescription: data.job_description,
           notes: data.notes,
           status: data.status as ApplicationStatus,
           appliedAt: data.applied_at,
@@ -145,7 +150,7 @@ export default function PipelinePage() {
         ...prev,
       ])
       setShowAddModal(false)
-      setAddForm({ jobTitle: '', companyName: '', jobUrl: '', notes: '', status: 'saved' })
+      setAddForm({ jobTitle: '', companyName: '', jobUrl: '', jobDescription: '', notes: '', status: 'saved' })
     }
     setIsSaving(false)
   }
@@ -161,6 +166,7 @@ export default function PipelinePage() {
       jobTitle: app.jobTitle,
       companyName: app.companyName,
       jobUrl: app.jobUrl ?? '',
+      jobDescription: app.jobDescription ?? '',
       notes: app.notes ?? '',
       status: app.status,
     })
@@ -175,6 +181,7 @@ export default function PipelinePage() {
         job_title: editForm.jobTitle.trim(),
         company_name: editForm.companyName.trim(),
         job_url: editForm.jobUrl.trim() || null,
+        job_description: editForm.jobDescription.trim() || null,
         notes: editForm.notes.trim() || null,
         status: editForm.status,
       })
@@ -184,7 +191,7 @@ export default function PipelinePage() {
       setApplications((prev) =>
         prev.map((a) =>
           a.id === editTarget.id
-            ? { ...a, jobTitle: editForm.jobTitle.trim(), companyName: editForm.companyName.trim(), jobUrl: editForm.jobUrl.trim() || null, notes: editForm.notes.trim() || null, status: editForm.status }
+            ? { ...a, jobTitle: editForm.jobTitle.trim(), companyName: editForm.companyName.trim(), jobUrl: editForm.jobUrl.trim() || null, jobDescription: editForm.jobDescription.trim() || null, notes: editForm.notes.trim() || null, status: editForm.status }
             : a
         )
       )
@@ -342,6 +349,15 @@ export default function PipelinePage() {
                 />
               </label>
               <label className={styles.fieldLabel}>
+                Job Description
+                <textarea
+                  className={cn(styles.fieldInput, styles.fieldTextarea)}
+                  placeholder="Paste the job description here..."
+                  value={addForm.jobDescription}
+                  onChange={(e) => setAddForm((f) => ({ ...f, jobDescription: e.target.value }))}
+                />
+              </label>
+              <label className={styles.fieldLabel}>
                 Status
                 <select
                   className={styles.fieldInput}
@@ -412,6 +428,15 @@ export default function PipelinePage() {
                   placeholder="https://..."
                   value={editForm.jobUrl}
                   onChange={(e) => setEditForm((f) => ({ ...f, jobUrl: e.target.value }))}
+                />
+              </label>
+              <label className={styles.fieldLabel}>
+                Job Description
+                <textarea
+                  className={cn(styles.fieldInput, styles.fieldTextarea)}
+                  placeholder="Paste the job description here..."
+                  value={editForm.jobDescription}
+                  onChange={(e) => setEditForm((f) => ({ ...f, jobDescription: e.target.value }))}
                 />
               </label>
               <label className={styles.fieldLabel}>

--- a/apps/web/src/pages/PipelinePage.tsx
+++ b/apps/web/src/pages/PipelinePage.tsx
@@ -78,36 +78,38 @@ export default function PipelinePage() {
 
   useEffect(() => {
     if (!user?.id) return
+    const userId = user.id
+
+    async function loadApplications() {
+      setIsLoading(true)
+      setError(null)
+      const { data, error: err } = await supabase
+        .from('job_applications')
+        .select('id, job_title, company_name, job_url, notes, status, applied_at, created_at')
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false })
+
+      if (err) {
+        setError('Failed to load applications.')
+      } else {
+        setApplications(
+          (data ?? []).map((row) => ({
+            id: row.id,
+            jobTitle: row.job_title,
+            companyName: row.company_name ?? '',
+            jobUrl: row.job_url,
+            notes: row.notes,
+            status: row.status as ApplicationStatus,
+            appliedAt: row.applied_at,
+            createdAt: row.created_at,
+          }))
+        )
+      }
+      setIsLoading(false)
+    }
+
     void loadApplications()
   }, [user?.id])
-
-  async function loadApplications() {
-    setIsLoading(true)
-    setError(null)
-    const { data, error: err } = await supabase
-      .from('job_applications')
-      .select('id, job_title, company_name, job_url, notes, status, applied_at, created_at')
-      .eq('user_id', user!.id)
-      .order('created_at', { ascending: false })
-
-    if (err) {
-      setError('Failed to load applications.')
-    } else {
-      setApplications(
-        (data ?? []).map((row) => ({
-          id: row.id,
-          jobTitle: row.job_title,
-          companyName: row.company_name ?? '',
-          jobUrl: row.job_url,
-          notes: row.notes,
-          status: row.status as ApplicationStatus,
-          appliedAt: row.applied_at,
-          createdAt: row.created_at,
-        }))
-      )
-    }
-    setIsLoading(false)
-  }
 
   async function handleAdd() {
     if (!user?.id || !addForm.jobTitle.trim() || !addForm.companyName.trim()) return

--- a/apps/web/src/pages/PipelinePage.tsx
+++ b/apps/web/src/pages/PipelinePage.tsx
@@ -73,6 +73,9 @@ export default function PipelinePage() {
   })
   const [isSaving, setIsSaving] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<JobApplication | null>(null)
+  const [editTarget, setEditTarget] = useState<JobApplication | null>(null)
+  const [editForm, setEditForm] = useState<AddFormState>({ jobTitle: '', companyName: '', jobUrl: '', notes: '', status: 'saved' })
+  const [isUpdating, setIsUpdating] = useState(false)
   const [dragId, setDragId] = useState<string | null>(null)
   const [dragOverCol, setDragOverCol] = useState<string | null>(null)
 
@@ -152,6 +155,44 @@ export default function PipelinePage() {
     await supabase.from('job_applications').update({ status }).eq('id', id)
   }
 
+  function openEdit(app: JobApplication) {
+    setEditTarget(app)
+    setEditForm({
+      jobTitle: app.jobTitle,
+      companyName: app.companyName,
+      jobUrl: app.jobUrl ?? '',
+      notes: app.notes ?? '',
+      status: app.status,
+    })
+  }
+
+  async function handleUpdate() {
+    if (!editTarget || !editForm.jobTitle.trim() || !editForm.companyName.trim()) return
+    setIsUpdating(true)
+    const { error: err } = await supabase
+      .from('job_applications')
+      .update({
+        job_title: editForm.jobTitle.trim(),
+        company_name: editForm.companyName.trim(),
+        job_url: editForm.jobUrl.trim() || null,
+        notes: editForm.notes.trim() || null,
+        status: editForm.status,
+      })
+      .eq('id', editTarget.id)
+
+    if (!err) {
+      setApplications((prev) =>
+        prev.map((a) =>
+          a.id === editTarget.id
+            ? { ...a, jobTitle: editForm.jobTitle.trim(), companyName: editForm.companyName.trim(), jobUrl: editForm.jobUrl.trim() || null, notes: editForm.notes.trim() || null, status: editForm.status }
+            : a
+        )
+      )
+      setEditTarget(null)
+    }
+    setIsUpdating(false)
+  }
+
   async function handleDelete() {
     if (!deleteTarget) return
     await supabase.from('job_applications').delete().eq('id', deleteTarget.id)
@@ -218,6 +259,7 @@ export default function PipelinePage() {
                       key={app.id}
                       className={styles.card}
                       draggable
+                      onClick={() => openEdit(app)}
                       onDragStart={() => handleDragStart(app.id)}
                       onDragEnd={() => { setDragId(null); setDragOverCol(null) }}
                     >
@@ -225,7 +267,7 @@ export default function PipelinePage() {
                         <p className={styles.cardTitle}>{app.jobTitle}</p>
                         <button
                           className={styles.cardDelete}
-                          onClick={() => setDeleteTarget(app)}
+                          onClick={(e) => { e.stopPropagation(); setDeleteTarget(app) }}
                           aria-label="Delete application"
                         >
                           <X size={12} />
@@ -245,19 +287,11 @@ export default function PipelinePage() {
                               rel="noopener noreferrer"
                               className={styles.cardLink}
                               aria-label="Open job posting"
+                              onClick={(e) => e.stopPropagation()}
                             >
                               <ExternalLink size={12} />
                             </a>
                           )}
-                          <select
-                            className={styles.statusSelect}
-                            value={app.status}
-                            onChange={(e) => handleStatusChange(app.id, e.target.value as ApplicationStatus)}
-                          >
-                            {ALL_STATUSES.map((s) => (
-                              <option key={s} value={s}>{STATUS_LABELS[s]}</option>
-                            ))}
-                          </select>
                         </div>
                       </div>
                     </div>
@@ -338,6 +372,79 @@ export default function PipelinePage() {
                 disabled={!addForm.jobTitle.trim() || !addForm.companyName.trim()}
               >
                 Add
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Edit application modal */}
+      {editTarget && (
+        <div className={styles.modalOverlay} onClick={() => setEditTarget(null)}>
+          <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.modalHeader}>
+              <h2 className={styles.modalTitle}>Edit Application</h2>
+              <button className={styles.modalClose} onClick={() => setEditTarget(null)} aria-label="Close">
+                <X size={16} />
+              </button>
+            </div>
+            <div className={styles.modalBody}>
+              <label className={styles.fieldLabel}>
+                <span>Job Title <span className={styles.required}>*</span></span>
+                <input
+                  className={styles.fieldInput}
+                  value={editForm.jobTitle}
+                  onChange={(e) => setEditForm((f) => ({ ...f, jobTitle: e.target.value }))}
+                />
+              </label>
+              <label className={styles.fieldLabel}>
+                <span>Company <span className={styles.required}>*</span></span>
+                <input
+                  className={styles.fieldInput}
+                  value={editForm.companyName}
+                  onChange={(e) => setEditForm((f) => ({ ...f, companyName: e.target.value }))}
+                />
+              </label>
+              <label className={styles.fieldLabel}>
+                Job URL
+                <input
+                  className={styles.fieldInput}
+                  placeholder="https://..."
+                  value={editForm.jobUrl}
+                  onChange={(e) => setEditForm((f) => ({ ...f, jobUrl: e.target.value }))}
+                />
+              </label>
+              <label className={styles.fieldLabel}>
+                Status
+                <select
+                  className={styles.fieldInput}
+                  value={editForm.status}
+                  onChange={(e) => setEditForm((f) => ({ ...f, status: e.target.value as ApplicationStatus }))}
+                >
+                  {ALL_STATUSES.map((s) => (
+                    <option key={s} value={s}>{STATUS_LABELS[s]}</option>
+                  ))}
+                </select>
+              </label>
+              <label className={styles.fieldLabel}>
+                Notes
+                <textarea
+                  className={cn(styles.fieldInput, styles.fieldTextarea)}
+                  placeholder="Any notes about this role..."
+                  value={editForm.notes}
+                  onChange={(e) => setEditForm((f) => ({ ...f, notes: e.target.value }))}
+                />
+              </label>
+            </div>
+            <div className={styles.modalFooter}>
+              <Button variant="secondary" onClick={() => setEditTarget(null)}>Cancel</Button>
+              <Button
+                variant="primary"
+                onClick={handleUpdate}
+                loading={isUpdating}
+                disabled={!editForm.jobTitle.trim() || !editForm.companyName.trim()}
+              >
+                Save
               </Button>
             </div>
           </div>

--- a/supabase/migrations/20260419000001_add_company_name_to_job_applications.sql
+++ b/supabase/migrations/20260419000001_add_company_name_to_job_applications.sql
@@ -1,0 +1,2 @@
+-- Add company_name text column to job_applications for direct entry
+ALTER TABLE job_applications ADD COLUMN company_name TEXT;


### PR DESCRIPTION
# PR Description

## Application Pipeline

Adds a dedicated Applications page with a full kanban board for tracking job applications, plus dashboard improvements.

### New: `/applications` page
- Kanban board with 6 columns: Saved → Applied → Phone Screen → Interviewing → Offer → Closed
- Drag and drop cards between columns to change status
- Click any card to open an edit modal (job title, company, URL, job description, status, notes)
- Changing status in the edit modal moves the card to the correct column
- Add Application modal with all fields
- Delete with confirmation dialog
- Columns fill the full page width

### Database
- Migration: adds `company_name TEXT` column to `job_applications` (auto-applied on merge via `deploy-supabase.yml`)

### Dashboard updates
- Application Pipeline card now shows **Applied / Interviews / Offers** with color-coded values (blue / amber / green) and a matching progress bar
- Vertical dividers between stat columns
- "Manage in Applications →" link to the pipeline page
- Empty state links to `/applications`

closes #138 