### PR TITLE
Fix: selected card styling encompasses role list

### DIFF
--- a/apps/web/src/pages/ResearchPage.module.css
+++ b/apps/web/src/pages/ResearchPage.module.css
@@ -59,7 +59,7 @@
 /* ── Left sidebar ────────────────────────────────────────────────────────── */
 
 .sidebar {
-  width: 210px;
+  width: 240px;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
@@ -117,6 +117,18 @@
   min-height: 0;
 }
 
+/* Company group: wraps card + role list, carries the selected state */
+
+.companyGroup {
+  border-radius: var(--radius-lg);
+}
+
+.companyGroupSelected {
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-lg);
+  background: var(--color-primary-subtle);
+}
+
 .companyCard {
   display: flex;
   align-items: center;
@@ -129,14 +141,21 @@
   transition: box-shadow 0.15s, border-color 0.15s, background-color 0.15s;
 }
 
+.companyGroupSelected .companyCard {
+  border-color: transparent;
+  background: transparent;
+  box-shadow: none;
+}
+
 .companyCard:hover {
   border-color: var(--color-border-strong);
   box-shadow: var(--shadow-sm);
 }
 
-.companyCardSelected {
-  border-color: var(--color-primary);
-  background: var(--color-primary-subtle);
+.companyGroupSelected .companyCard:hover {
+  border-color: transparent;
+  background: rgba(0, 0, 0, 0.04);
+  box-shadow: none;
 }
 
 
@@ -320,8 +339,7 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
-  padding: 0 0 var(--space-2) var(--space-6);
-  margin-top: -2px;
+  padding: var(--space-1) 0 var(--space-2) var(--space-6);
 }
 
 .roleItem {

--- a/apps/web/src/pages/ResearchPage.tsx
+++ b/apps/web/src/pages/ResearchPage.tsx
@@ -318,12 +318,15 @@ export default function ResearchPage() {
 
           <div className={styles.companyList}>
             {filteredCompanies.map((company) => (
-              <div key={company.id}>
+              <div
+                key={company.id}
+                className={cn(
+                  styles.companyGroup,
+                  selectedCompanyId === company.id && styles.companyGroupSelected,
+                )}
+              >
                 <div
-                  className={cn(
-                    styles.companyCard,
-                    selectedCompanyId === company.id && styles.companyCardSelected,
-                  )}
+                  className={styles.companyCard}
                   onClick={() => handleSelectCompany(company)}
                 >
                   <button


### PR DESCRIPTION
## Summary
- The blue selected border now wraps the entire company group (card + expanded role list) instead of just the card row, so the selection is visually coherent
- Widened sidebar from 210px → 240px to reduce company name truncation (e.g. "Genera..." → "Generative...")
- Removed the old `margin-top: -2px` hack from the role list (no longer needed)
- Fixed the hover state so hovering a selected card doesn't flash a gray border

## Test plan
- [ ] Select a company → blue border wraps the card AND the expanded roles below it
- [ ] Hovering a selected card doesn't revert the border to gray
- [ ] Longer company names show more characters before truncating

🤖 Generated with [Claude Code](https://claude.com/claude-code)