### PR TITLE
fix: include 'saved' status in dashboard pipeline count

### DIFF
--- a/apps/web/src/hooks/useDashboardData.ts
+++ b/apps/web/src/hooks/useDashboardData.ts
@@ -36,6 +36,7 @@ interface RawPracticeSession {
 }
 
 type ApplicationStatus =
+  | 'saved'
   | 'applied'
   | 'phone_screen'
   | 'interviewing'
@@ -44,6 +45,7 @@ type ApplicationStatus =
   | 'withdrawn'
 
 const KNOWN_STATUSES: readonly ApplicationStatus[] = [
+  'saved',
   'applied',
   'phone_screen',
   'interviewing',


### PR DESCRIPTION
## Problem
The Application Pipeline card on the dashboard always showed 0 even after adding jobs via the Pipeline page.

Root cause: `useDashboardData.ts` had its own local `ApplicationStatus` type and `KNOWN_STATUSES` array that were missing `'saved'`. The Pipeline page defaults new jobs to `'saved'` status, so `isApplicationStatus()` filtered them out and `total` was always 0.

## Fix
Add `'saved'` to both the `ApplicationStatus` type and `KNOWN_STATUSES` in `useDashboardData.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)