### PR TITLE
Minor application pipeline fixes

### DIFF
--- a/apps/web/src/hooks/useDashboardData.ts
+++ b/apps/web/src/hooks/useDashboardData.ts
@@ -355,7 +355,7 @@ export function useDashboardData({
 
         const statuses = (data ?? []).map((row) => row.status).filter(isApplicationStatus)
         setPipeline({
-          total: statuses.length,
+          applied: statuses.filter((s) => s === 'applied').length,
           interviews: statuses.filter((s) => INTERVIEW_STATUSES.includes(s)).length,
           offers: statuses.filter((s) => s === 'offer').length,
         })

--- a/apps/web/src/pages/DashboardPage.module.css
+++ b/apps/web/src/pages/DashboardPage.module.css
@@ -432,25 +432,24 @@
 .progressTrack {
   height: 8px;
   border-radius: var(--radius-full);
-  background-color: var(--color-bg-muted);
-  position: relative;
   overflow: hidden;
+  display: flex;
 }
 
-.progressLayer {
-  position: absolute;
-  left: 0;
-  top: 0;
+.progressSegment {
   height: 100%;
-  border-radius: var(--radius-full);
-  transition: width 0.4s ease;
+  transition: flex 0.4s ease;
 }
 
-.progressLayerMid {
+.progressSegmentApplied {
+  background-color: #3b82f6;
+}
+
+.progressSegmentInterviews {
   background-color: #f59e0b;
 }
 
-.progressLayerTop {
+.progressSegmentOffers {
   background-color: #10b981;
 }
 

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -261,7 +261,7 @@ function ApplicationPipelineCard({
           <RangePills value={range} onChange={onRangeChange} />
         </div>
 
-        {pipeline.total === 0 ? (
+        {pipeline.applied === 0 && pipeline.interviews === 0 && pipeline.offers === 0 ? (
           <div className={styles.emptyState}>
             <p className={styles.emptyText}>
               {range === 'week'
@@ -277,7 +277,7 @@ function ApplicationPipelineCard({
             <div className={styles.pipelineStats}>
               <div className={styles.pipelineStat}>
                 <span className={styles.pipelineLabel}>Applied</span>
-                <span className={cn(styles.pipelineValue, styles.pipelineValueApplied)}>{pipeline.total}</span>
+                <span className={cn(styles.pipelineValue, styles.pipelineValueApplied)}>{pipeline.applied}</span>
               </div>
               <div className={styles.pipelineStat}>
                 <span className={styles.pipelineLabel}>Interviews</span>
@@ -291,12 +291,16 @@ function ApplicationPipelineCard({
 
             <div className={styles.progressTrack}>
               <div
-                className={cn(styles.progressLayer, styles.progressLayerMid)}
-                style={{ width: `${(pipeline.interviews / pipeline.total) * 100}%` }}
+                className={cn(styles.progressSegment, styles.progressSegmentApplied)}
+                style={{ flex: pipeline.applied }}
               />
               <div
-                className={cn(styles.progressLayer, styles.progressLayerTop)}
-                style={{ width: `${(pipeline.offers / pipeline.total) * 100}%` }}
+                className={cn(styles.progressSegment, styles.progressSegmentInterviews)}
+                style={{ flex: pipeline.interviews }}
+              />
+              <div
+                className={cn(styles.progressSegment, styles.progressSegmentOffers)}
+                style={{ flex: pipeline.offers }}
               />
             </div>
 
@@ -366,7 +370,7 @@ export default function DashboardPage(): JSX.Element {
           <ApplicationPipelineCard
             range={pipelineRange}
             onRangeChange={setPipelineRange}
-            pipeline={data?.pipeline ?? { total: 0, interviews: 0, offers: 0 }}
+            pipeline={data?.pipeline ?? { applied: 0, interviews: 0, offers: 0 }}
           />
         </div>
       </div>

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -114,7 +114,7 @@ export interface PracticeConsistencyData {
 }
 
 export interface PipelineCounts {
-  total: number
+  applied: number
   interviews: number
   offers: number
 }


### PR DESCRIPTION
# Fix Dashboard Pipeline Bar — Proportional Segments & Correct Status Counting

## Problem

The Application Pipeline card on the dashboard had two bugs:

1. **Progress bar did not fill correctly.** The bar used overlapping absolute-positioned layers, so segments could cover each other rather than each taking up a proportional share of the full bar width.
2. **Status counts were wrong.** "Applied" was using a `total` count that included all statuses (including saved and closed). The three stages were not mapped to the correct underlying enum values.

## Changes

### Progress bar

Replaced the overlapping absolute-layer approach with a `display: flex` track where each segment's `flex` value equals its count. This ensures the three segments always together fill 100% of the bar, each occupying a proportion matching its count relative to the total.

- Applied segment: blue (`#3b82f6`)
- Interviews segment: amber (`#f59e0b`)
- Offers segment: green (`#10b981`)

### Counting logic

| Dashboard label | Statuses counted |
|---|---|
| Applied | `applied` only |
| Interviews | `phone_screen` + `interviewing` |
| Offers | `offer` only |

Applications in `saved`, `rejected`, and `withdrawn` columns are excluded from all counts.

### Renamed `total` → `applied`

The `PipelineCounts` interface field `total` was renamed to `applied` to reflect that it only counts the `applied` status, not all applications.


closes #144 