### PR TITLE
feat: connect gamification to research page (#111)

### DIFF
--- a/apps/web/src/hooks/useResearchChat.ts
+++ b/apps/web/src/hooks/useResearchChat.ts
@@ -2,7 +2,8 @@ import { useState, useCallback, useEffect, useRef } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useTrackActivity } from '@/hooks/useTrackActivity'
 import { supabase } from '@/lib/supabase'
-import type { Message } from '@/types'
+import { awardGamificationEvent, GAMIFICATION_EVENT_TYPES } from '@/lib/gamification'
+import type { Badge, Message } from '@/types'
 import { stripResearchChatMarkdown } from '@/utils/stripResearchChatMarkdown'
 
 const RATE_LIMIT_FRIENDLY_MESSAGE =
@@ -70,11 +71,13 @@ export function useResearchChat({
   jobDescription,
   companyProfileId,
   roleId,
+  onXpAwarded,
 }: {
   companies: string[]
   jobDescription?: string
   companyProfileId?: string | null
   roleId?: string | null
+  onXpAwarded?: (result: { xpAwarded: number; newBadges: Badge[] }) => void
 }) {
   const { session, user } = useAuth()
   const { trackEvent } = useTrackActivity('research')
@@ -85,6 +88,8 @@ export function useResearchChat({
   const sessionAttachmentRef = useRef<AttachmentPayload | null>(null)
   const loadedRoleRef = useRef<string | null>(null)
   const loadedCompanyRef = useRef<string | null>(null)
+  const onXpAwardedRef = useRef(onXpAwarded)
+  onXpAwardedRef.current = onXpAwarded
 
   // Load existing research session for this role
   useEffect(() => {
@@ -240,6 +245,8 @@ export function useResearchChat({
         return
       }
 
+      const isNewSession = !sessionIdRef.current
+
       const userMsg = msg('user', displayContent.trim())
       const placeholder = msg('assistant', '')
       setMessages((prev) => [...prev, userMsg, placeholder])
@@ -330,6 +337,15 @@ export function useResearchChat({
           persistMessages(prev)
           return prev
         })
+
+        // Award XP for the first message in a new session
+        if (isNewSession && user?.id) {
+          void awardGamificationEvent(user.id, GAMIFICATION_EVENT_TYPES.RESEARCH_CHAT_MESSAGE).then(
+            (result) => {
+              if (result.success) onXpAwardedRef.current?.({ xpAwarded: result.xpAwarded, newBadges: result.newBadges })
+            },
+          )
+        }
       } catch {
         setPlaceholderContent(
           "Couldn't reach the research service right now. Please check your connection and try again.",
@@ -338,7 +354,7 @@ export function useResearchChat({
         setIsStreaming(false)
       }
     },
-    [session?.access_token, companies, jobDescription, messages, persistMessages, trackEvent],
+    [session?.access_token, companies, jobDescription, messages, persistMessages, trackEvent, user],
   )
 
   return { messages, isStreaming, sendMessage, resetMessages, clearSession, sessionId }

--- a/apps/web/src/lib/gamification/computeGamificationData.test.ts
+++ b/apps/web/src/lib/gamification/computeGamificationData.test.ts
@@ -18,6 +18,13 @@ describe('eventCatalog (resume actions)', () => {
   })
 })
 
+describe('eventCatalog (research actions)', () => {
+  it('maps research event types to their configured XP', () => {
+    expect(getXpForEventType(GAMIFICATION_EVENT_TYPES.RESEARCH_COMPANY_ADDED)).toBe(20)
+    expect(getXpForEventType(GAMIFICATION_EVENT_TYPES.RESEARCH_CHAT_MESSAGE)).toBe(10)
+  })
+})
+
 describe('computeGamificationData', () => {
   it('sums resume ledger rows into total XP', () => {
     const data = computeGamificationData({
@@ -78,5 +85,40 @@ describe('computeGamificationData', () => {
       { event_type: GAMIFICATION_EVENT_TYPES.RESUME_SESSION_UPLOAD, xp_awarded: 30 },
     ]
     expect(sumLedgerXp(rows)).toBe(31)
+  })
+
+  it('earns company_scout after adding first company', () => {
+    const data = computeGamificationData({
+      practiceCount: 0,
+      researchCount: 0,
+      applicationCount: 0,
+      xpEvents: [{ event_type: GAMIFICATION_EVENT_TYPES.RESEARCH_COMPANY_ADDED, xp_awarded: 20 }],
+    })
+    expect(data.badges.find((b) => b.id === 'company_scout')?.earned).toBe(true)
+    expect(data.badges.find((b) => b.id === 'curious_researcher')?.earned).toBe(false)
+  })
+
+  it('earns curious_researcher after first research chat message', () => {
+    const data = computeGamificationData({
+      practiceCount: 0,
+      researchCount: 0,
+      applicationCount: 0,
+      xpEvents: [{ event_type: GAMIFICATION_EVENT_TYPES.RESEARCH_CHAT_MESSAGE, xp_awarded: 10 }],
+    })
+    expect(data.badges.find((b) => b.id === 'curious_researcher')?.earned).toBe(true)
+    expect(data.badges.find((b) => b.id === 'company_scout')?.earned).toBe(false)
+  })
+
+  it('includes research ledger XP in total', () => {
+    const data = computeGamificationData({
+      practiceCount: 0,
+      researchCount: 0,
+      applicationCount: 0,
+      xpEvents: [
+        { event_type: GAMIFICATION_EVENT_TYPES.RESEARCH_COMPANY_ADDED, xp_awarded: 20 },
+        { event_type: GAMIFICATION_EVENT_TYPES.RESEARCH_CHAT_MESSAGE, xp_awarded: 10 },
+      ],
+    })
+    expect(data.totalXp).toBe(30)
   })
 })

--- a/apps/web/src/lib/gamification/computeGamificationData.ts
+++ b/apps/web/src/lib/gamification/computeGamificationData.ts
@@ -48,6 +48,8 @@ function ledgerCounts(xpEvents: XpEventRow[]) {
     resumeTailorRuns: n(GAMIFICATION_EVENT_TYPES.RESUME_AUTO_TAILOR),
     resumeApplyEdits: n(GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT),
     resumeDeclineEdits: n(GAMIFICATION_EVENT_TYPES.RESUME_DECLINE_TAILOR_EDIT),
+    companiesAdded: n(GAMIFICATION_EVENT_TYPES.RESEARCH_COMPANY_ADDED),
+    researchMessages: n(GAMIFICATION_EVENT_TYPES.RESEARCH_CHAT_MESSAGE),
   }
 }
 
@@ -60,6 +62,8 @@ interface Counts {
   resumeTailorRuns: number
   resumeApplyEdits: number
   resumeDeclineEdits: number
+  companiesAdded: number
+  researchMessages: number
   totalXp: number
 }
 
@@ -143,6 +147,20 @@ const BADGE_DEFS: readonly BadgeDef[] = [
     icon: '🧭',
     check: ({ resumeDeclineEdits }) => resumeDeclineEdits >= 3,
   },
+  {
+    id: 'company_scout',
+    label: 'Company Scout',
+    description: 'Add your first company to your research board',
+    icon: '🏢',
+    check: ({ companiesAdded }) => companiesAdded >= 1,
+  },
+  {
+    id: 'curious_researcher',
+    label: 'Curious Researcher',
+    description: 'Ask your first research question',
+    icon: '🔍',
+    check: ({ researchMessages }) => researchMessages >= 1,
+  },
 ] as const
 
 /** Derives level, XP, and badges from session counts plus `user_xp_events` rows. */
@@ -171,6 +189,8 @@ export function computeGamificationData(sources: GamificationSources): Gamificat
     resumeTailorRuns: ledger.resumeTailorRuns,
     resumeApplyEdits: ledger.resumeApplyEdits,
     resumeDeclineEdits: ledger.resumeDeclineEdits,
+    companiesAdded: ledger.companiesAdded,
+    researchMessages: ledger.researchMessages,
     totalXp,
   }
 

--- a/apps/web/src/lib/gamification/eventCatalog.ts
+++ b/apps/web/src/lib/gamification/eventCatalog.ts
@@ -8,6 +8,8 @@ export const GAMIFICATION_EVENT_TYPES = {
   RESUME_AUTO_TAILOR: 'resume_auto_tailor',
   RESUME_APPLY_TAILOR_EDIT: 'resume_apply_tailor_edit',
   RESUME_DECLINE_TAILOR_EDIT: 'resume_decline_tailor_edit',
+  RESEARCH_COMPANY_ADDED: 'research_company_added',
+  RESEARCH_CHAT_MESSAGE: 'research_chat_message',
 } as const
 
 export type ResumeGamificationEventType =
@@ -15,6 +17,10 @@ export type ResumeGamificationEventType =
   | typeof GAMIFICATION_EVENT_TYPES.RESUME_AUTO_TAILOR
   | typeof GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT
   | typeof GAMIFICATION_EVENT_TYPES.RESUME_DECLINE_TAILOR_EDIT
+
+export type ResearchGamificationEventType =
+  | typeof GAMIFICATION_EVENT_TYPES.RESEARCH_COMPANY_ADDED
+  | typeof GAMIFICATION_EVENT_TYPES.RESEARCH_CHAT_MESSAGE
 
 /** Must match `xp_awarded` written at insert time (see `useInterviewChat`, `recordXpEvent`). */
 export const XP_BY_EVENT_TYPE: Record<string, number> = {
@@ -26,6 +32,8 @@ export const XP_BY_EVENT_TYPE: Record<string, number> = {
   [GAMIFICATION_EVENT_TYPES.RESUME_AUTO_TAILOR]: 40,
   [GAMIFICATION_EVENT_TYPES.RESUME_APPLY_TAILOR_EDIT]: 15,
   [GAMIFICATION_EVENT_TYPES.RESUME_DECLINE_TAILOR_EDIT]: 10,
+  [GAMIFICATION_EVENT_TYPES.RESEARCH_COMPANY_ADDED]: 20,
+  [GAMIFICATION_EVENT_TYPES.RESEARCH_CHAT_MESSAGE]: 10,
 }
 
 const RESUME_TOAST_TITLE: Partial<Record<ResumeGamificationEventType, string>> = {
@@ -35,10 +43,19 @@ const RESUME_TOAST_TITLE: Partial<Record<ResumeGamificationEventType, string>> =
   [GAMIFICATION_EVENT_TYPES.RESUME_DECLINE_TAILOR_EDIT]: 'Suggestion declined',
 }
 
+const RESEARCH_TOAST_TITLE: Partial<Record<ResearchGamificationEventType, string>> = {
+  [GAMIFICATION_EVENT_TYPES.RESEARCH_COMPANY_ADDED]: 'Company added to board',
+  [GAMIFICATION_EVENT_TYPES.RESEARCH_CHAT_MESSAGE]: 'Research question asked',
+}
+
 export function getXpForEventType(eventType: string): number {
   return XP_BY_EVENT_TYPE[eventType] ?? 0
 }
 
 export function getResumeToastTitle(eventType: ResumeGamificationEventType): string {
   return RESUME_TOAST_TITLE[eventType] ?? 'Progress saved'
+}
+
+export function getResearchToastTitle(eventType: ResearchGamificationEventType): string {
+  return RESEARCH_TOAST_TITLE[eventType] ?? 'Research progress'
 }

--- a/apps/web/src/lib/gamification/index.ts
+++ b/apps/web/src/lib/gamification/index.ts
@@ -1,9 +1,11 @@
 export {
   GAMIFICATION_EVENT_TYPES,
   getResumeToastTitle,
+  getResearchToastTitle,
   getXpForEventType,
   XP_BY_EVENT_TYPE,
   type ResumeGamificationEventType,
+  type ResearchGamificationEventType,
 } from './eventCatalog'
 export {
   computeGamificationData,

--- a/apps/web/src/pages/ResearchPage.tsx
+++ b/apps/web/src/pages/ResearchPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { Plus, Search, Send, X, Paperclip, Star, Trash2, ChevronRight, ChevronDown, Play, Briefcase } from 'lucide-react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
@@ -6,11 +6,18 @@ import { useResearchChat } from '@/hooks/useResearchChat'
 import { useResearchCompanies } from '@/hooks/useResearchCompanies'
 import { useCompanyRoles } from '@/hooks/useCompanyRoles'
 import { StandardToast } from '@/components/interview/Toast'
+import { XpToast } from '@/components/interview/XpToast'
 import AddCompanyModal from './AddCompanyPage'
 import { cn } from '@/utils/cn'
 import { readResearchChatAttachment } from '@/utils/readResearchChatAttachment'
 import { ConfirmModal } from '@/utils/ConfirmModal'
-import type { CompanyRole } from '@/types'
+import {
+  awardGamificationEvent,
+  GAMIFICATION_EVENT_TYPES,
+  getResearchToastTitle,
+  type ResearchGamificationEventType,
+} from '@/lib/gamification'
+import type { Badge, CompanyRole } from '@/types'
 import styles from './ResearchPage.module.css'
 
 interface CompanyProfile {
@@ -73,6 +80,42 @@ export default function ResearchPage() {
     variant: 'success' | 'error'
   } | null>(null)
   const [companyToDelete, setCompanyToDelete] = useState<{ id: string; name: string } | null>(null)
+
+  type GamificationToastItem =
+    | { id: number; variant: 'xp'; xp: number; label: string }
+    | { id: number; variant: 'achievement'; label: string }
+  const [gamificationToasts, setGamificationToasts] = useState<GamificationToastItem[]>([])
+  const pushGamificationToast = useCallback((item: GamificationToastItem) => {
+    setGamificationToasts((prev) => [...prev, item])
+  }, [])
+
+  const queueResearchGamification = useCallback(
+    (eventType: ResearchGamificationEventType) => {
+      if (!user?.id) return
+      void awardGamificationEvent(user.id, eventType).then((result) => {
+        if (!result.success) return
+        pushGamificationToast({ id: Date.now() + Math.random(), variant: 'xp', xp: result.xpAwarded, label: getResearchToastTitle(eventType) })
+        result.newBadges.forEach((badge: Badge, i: number) => {
+          window.setTimeout(() => {
+            pushGamificationToast({ id: Date.now() + Math.random(), variant: 'achievement', label: `${badge.icon} ${badge.label}` })
+          }, 320 * (i + 1))
+        })
+      })
+    },
+    [user?.id, pushGamificationToast],
+  )
+
+  const handleChatXpAwarded = useCallback(
+    ({ xpAwarded, newBadges }: { xpAwarded: number; newBadges: Badge[] }) => {
+      pushGamificationToast({ id: Date.now() + Math.random(), variant: 'xp', xp: xpAwarded, label: getResearchToastTitle(GAMIFICATION_EVENT_TYPES.RESEARCH_CHAT_MESSAGE as ResearchGamificationEventType) })
+      newBadges.forEach((badge: Badge, i: number) => {
+        window.setTimeout(() => {
+          pushGamificationToast({ id: Date.now() + Math.random(), variant: 'achievement', label: `${badge.icon} ${badge.label}` })
+        }, 320 * (i + 1))
+      })
+    },
+    [pushGamificationToast],
+  )
 
   // Expandable roles state
   const [expandedCompanyId, setExpandedCompanyId] = useState<string | null>(
@@ -161,6 +204,7 @@ export default function ResearchPage() {
     jobDescription: activeRole?.jobDescription || undefined,
     companyProfileId: activeCompanyProfileId || null,
     roleId: activeRole?.id || null,
+    onXpAwarded: handleChatXpAwarded,
   })
 
   const filteredCompanies = dbCompanies
@@ -292,6 +336,16 @@ export default function ResearchPage() {
 
   return (
     <div className={styles.page}>
+      {gamificationToasts.map((t, i) => (
+        <XpToast
+          key={t.id}
+          variant={t.variant}
+          xp={t.variant === 'xp' ? t.xp : undefined}
+          label={t.label}
+          style={{ bottom: `calc(1.5rem + ${i * 3.5}rem)` }}
+          onDone={() => setGamificationToasts((prev) => prev.filter((x) => x.id !== t.id))}
+        />
+      ))}
       <div className={styles.header}>
         <div>
           <h1 className={styles.title}>Research Board</h1>
@@ -647,6 +701,7 @@ export default function ResearchPage() {
           setSearchQuery(newName)
           await refreshCompanies()
           setToastConfig({ message: `Added ${newName} to your board!`, variant: 'success' })
+          queueResearchGamification(GAMIFICATION_EVENT_TYPES.RESEARCH_COMPANY_ADDED as ResearchGamificationEventType)
         }}
       />
       <ConfirmModal


### PR DESCRIPTION
## Summary
- Adds `RESEARCH_COMPANY_ADDED` (20 XP) and `RESEARCH_CHAT_MESSAGE` (10 XP) event types to the gamification catalog
- Awards XP + shows `XpToast` when a company is added via `AddCompanyModal` in `ResearchPage`
- Awards XP + shows `XpToast` on the first message of a new research chat session (detected inside `useResearchChat` when `sessionIdRef.current === null`)
- Adds two new badges: **Company Scout** (first company added) and **Curious Researcher** (first research question asked)

## Test plan
- [ ] Add a new company via Research Board → should see +20 XP toast; on first add, Company Scout badge toast appears
- [ ] Select a company and send a first chat message → should see +10 XP toast; on first ever message, Curious Researcher badge toast appears
- [ ] Subsequent messages in the same session do not re-fire the chat XP toast
- [ ] Clearing chat and sending a new first message fires XP again (new session)
- [ ] All 10 unit tests in `computeGamificationData.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)