### PR TITLE
feat: add account settings page (#130)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,6 +10,7 @@ import InterviewPage from '@/pages/InterviewPage'
 import ResearchPage from '@/pages/ResearchPage'
 import ResumePage from '@/pages/ResumePage'
 import PipelinePage from '@/pages/PipelinePage'
+import SettingsPage from '@/pages/SettingsPage'
 
 export default function App() {
   return (
@@ -32,6 +33,7 @@ export default function App() {
             <Route path="research" element={<ResearchPage />} />
             <Route path="resume" element={<ResumePage />} />
             <Route path="applications" element={<PipelinePage />} />
+            <Route path="settings" element={<SettingsPage />} />
           </Route>
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { NavLink, Outlet, useLocation } from 'react-router-dom'
-import { ChevronDown, LogOut, Moon, Star, Sun } from 'lucide-react'
+import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom'
+import { ChevronDown, LogOut, Moon, Settings, Star, Sun } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useTheme } from '@/contexts/ThemeContext'
 import { useConsistencyMetrics } from '@/contexts/ConsistencyMetricsContext'
@@ -36,6 +36,7 @@ function useMaxStreak(): number | null {
 export default function AppShell(): JSX.Element {
   const { user, signOut } = useAuth()
   const { theme, toggleTheme } = useTheme()
+  const navigate = useNavigate()
   const { data: gamification } = useGamificationData()
   const streak = useMaxStreak()
 
@@ -180,6 +181,18 @@ export default function AppShell(): JSX.Element {
                   <p className={styles.dropdownEmail}>{user?.email}</p>
                 </div>
                 <div className={styles.dropdownDivider} />
+                <button
+                  className={styles.dropdownItem}
+                  role="menuitem"
+                  onClick={() => {
+                    setMenuOpen(false)
+                    navigate('/settings')
+                  }}
+                  type="button"
+                >
+                  <Settings size={14} />
+                  Settings
+                </button>
                 <button
                   className={styles.dropdownItem}
                   role="menuitem"

--- a/apps/web/src/pages/SettingsPage.module.css
+++ b/apps/web/src/pages/SettingsPage.module.css
@@ -1,0 +1,246 @@
+/* ── Page shell ─────────────────────────────────────────────────────────── */
+
+.page {
+  max-width: 640px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.header {
+  margin-bottom: 4px;
+}
+
+.title {
+  font-family: var(--font-mono);
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--ink-1);
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  font-size: var(--font-sm);
+  color: var(--ink-2);
+  margin-top: 0.375rem;
+}
+
+/* ── Section cards ───────────────────────────────────────────────────────── */
+
+.section {
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xs);
+}
+
+.sectionDanger {
+  background: var(--surface);
+  border: 1px solid color-mix(in oklch, var(--danger) 30%, var(--hairline));
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xs);
+}
+
+.sectionInner {
+  padding: 22px 24px;
+}
+
+.sectionTitle {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink-1);
+  letter-spacing: -0.01em;
+  margin-bottom: 4px;
+}
+
+.sectionTitleDanger {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--danger);
+  letter-spacing: -0.01em;
+  margin-bottom: 14px;
+}
+
+.sectionDesc {
+  font-size: var(--font-sm);
+  color: var(--ink-3);
+  margin-bottom: 16px;
+}
+
+.currentValue {
+  color: var(--ink-2);
+  font-weight: 500;
+}
+
+/* ── Form ────────────────────────────────────────────────────────────────── */
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.fieldRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.label {
+  font-size: var(--font-sm);
+  font-weight: 500;
+  color: var(--ink-2);
+}
+
+.input {
+  width: 100%;
+  height: 36px;
+  padding: 0 12px;
+  font-family: var(--font-sans);
+  font-size: var(--font-sm);
+  color: var(--ink-1);
+  background: var(--surface-2);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+  outline: none;
+  transition:
+    border-color var(--dur-1) var(--ease-out),
+    box-shadow var(--dur-1) var(--ease-out);
+}
+
+.input::placeholder {
+  color: var(--ink-4);
+}
+
+.input:focus {
+  border-color: var(--blue);
+  box-shadow: var(--focus-ring);
+}
+
+.formFooter {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: var(--space-1);
+}
+
+/* ── Messages ────────────────────────────────────────────────────────────── */
+
+.errorMsg {
+  font-size: var(--font-sm);
+  color: var(--danger);
+}
+
+.successMsg {
+  font-size: var(--font-sm);
+  color: var(--success);
+}
+
+/* ── Buttons ─────────────────────────────────────────────────────────────── */
+
+.btn {
+  height: 34px;
+  padding: 0 16px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--surface);
+  background: var(--ink-1);
+  border: 0;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition:
+    background-color var(--dur-1) var(--ease-out),
+    opacity var(--dur-1) var(--ease-out);
+}
+
+.btn:hover:not(:disabled) {
+  background: var(--ink-2);
+}
+
+.btn:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.btnDanger {
+  height: 34px;
+  padding: 0 16px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--danger);
+  background: color-mix(in oklch, var(--danger) 10%, var(--surface));
+  border: 1px solid color-mix(in oklch, var(--danger) 30%, var(--hairline));
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition:
+    background-color var(--dur-1) var(--ease-out),
+    opacity var(--dur-1) var(--ease-out);
+}
+
+.btnDanger:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--danger) 18%, var(--surface));
+}
+
+.btnDanger:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring-danger);
+}
+
+.btnDanger:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* ── Danger zone row ─────────────────────────────────────────────────────── */
+
+.dangerRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.dangerRowLabel {
+  font-size: var(--font-sm);
+  font-weight: 500;
+  color: var(--ink-1);
+  margin-bottom: 3px;
+}
+
+.dangerRowDesc {
+  font-size: var(--font-xs);
+  color: var(--ink-3);
+  max-width: 360px;
+}
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+
+@media (max-width: 560px) {
+  .fieldRow {
+    grid-template-columns: 1fr;
+  }
+
+  .dangerRow {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,0 +1,219 @@
+import { useState, FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '@/contexts/AuthContext'
+import { supabase } from '@/lib/supabase'
+import styles from './SettingsPage.module.css'
+
+export default function SettingsPage() {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+
+  // ── Email section ───────────────────────────────────────────────────────
+  const [newEmail, setNewEmail] = useState('')
+  const [emailLoading, setEmailLoading] = useState(false)
+  const [emailError, setEmailError] = useState<string | null>(null)
+  const [emailSuccess, setEmailSuccess] = useState(false)
+
+  async function handleEmailUpdate(e: FormEvent) {
+    e.preventDefault()
+    setEmailError(null)
+    setEmailSuccess(false)
+    if (newEmail === user?.email) {
+      setEmailError('That is already your current email address.')
+      return
+    }
+    setEmailLoading(true)
+    const { error } = await supabase.auth.updateUser({ email: newEmail })
+    setEmailLoading(false)
+    if (error) {
+      setEmailError(error.message)
+    } else {
+      setEmailSuccess(true)
+      setNewEmail('')
+    }
+  }
+
+  // ── Password section ────────────────────────────────────────────────────
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [pwLoading, setPwLoading] = useState(false)
+  const [pwError, setPwError] = useState<string | null>(null)
+  const [pwSuccess, setPwSuccess] = useState(false)
+
+  async function handlePasswordUpdate(e: FormEvent) {
+    e.preventDefault()
+    setPwError(null)
+    setPwSuccess(false)
+    if (newPassword !== confirmPassword) {
+      setPwError('New passwords do not match.')
+      return
+    }
+    if (newPassword.length < 6) {
+      setPwError('Password must be at least 6 characters.')
+      return
+    }
+    if (!user?.email) {
+      setPwError('Unable to verify your identity. Please sign in again.')
+      return
+    }
+    setPwLoading(true)
+    // Re-authenticate with current password before updating
+    const { error: reAuthError } = await supabase.auth.signInWithPassword({
+      email: user.email,
+      password: currentPassword,
+    })
+    if (reAuthError) {
+      setPwLoading(false)
+      setPwError('Current password is incorrect.')
+      return
+    }
+    const { error } = await supabase.auth.updateUser({ password: newPassword })
+    setPwLoading(false)
+    if (error) {
+      setPwError(error.message)
+    } else {
+      setPwSuccess(true)
+      setCurrentPassword('')
+      setNewPassword('')
+      setConfirmPassword('')
+    }
+  }
+
+  // ── Danger zone ─────────────────────────────────────────────────────────
+  const [signOutAllLoading, setSignOutAllLoading] = useState(false)
+
+  async function handleSignOutAll() {
+    setSignOutAllLoading(true)
+    await supabase.auth.signOut({ scope: 'global' })
+    setSignOutAllLoading(false)
+    navigate('/login')
+  }
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.header}>
+        <h1 className={styles.title}>Settings</h1>
+        <p className={styles.subtitle}>Manage your account and security preferences</p>
+      </div>
+
+      {/* ── Email ── */}
+      <section className={styles.section}>
+        <div className={styles.sectionInner}>
+          <h2 className={styles.sectionTitle}>Email address</h2>
+          <p className={styles.sectionDesc}>
+            Current: <span className={styles.currentValue}>{user?.email}</span>
+          </p>
+          <form onSubmit={handleEmailUpdate} className={styles.form}>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="new-email">New email address</label>
+              <input
+                id="new-email"
+                type="email"
+                className={styles.input}
+                value={newEmail}
+                onChange={(e) => setNewEmail(e.target.value)}
+                placeholder="you@example.com"
+                autoComplete="email"
+                required
+              />
+            </div>
+            {emailError && <p className={styles.errorMsg}>{emailError}</p>}
+            {emailSuccess && (
+              <p className={styles.successMsg}>
+                Verification email sent. Check your inbox to confirm the change.
+              </p>
+            )}
+            <div className={styles.formFooter}>
+              <button type="submit" className={styles.btn} disabled={emailLoading || !newEmail}>
+                {emailLoading ? 'Saving…' : 'Update email'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      {/* ── Password ── */}
+      <section className={styles.section}>
+        <div className={styles.sectionInner}>
+          <h2 className={styles.sectionTitle}>Change password</h2>
+          <form onSubmit={handlePasswordUpdate} className={styles.form}>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="current-pw">Current password</label>
+              <input
+                id="current-pw"
+                type="password"
+                className={styles.input}
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                autoComplete="current-password"
+                required
+              />
+            </div>
+            <div className={styles.fieldRow}>
+              <div className={styles.field}>
+                <label className={styles.label} htmlFor="new-pw">New password</label>
+                <input
+                  id="new-pw"
+                  type="password"
+                  className={styles.input}
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  autoComplete="new-password"
+                  minLength={6}
+                  required
+                />
+              </div>
+              <div className={styles.field}>
+                <label className={styles.label} htmlFor="confirm-pw">Confirm new password</label>
+                <input
+                  id="confirm-pw"
+                  type="password"
+                  className={styles.input}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  autoComplete="new-password"
+                  required
+                />
+              </div>
+            </div>
+            {pwError && <p className={styles.errorMsg}>{pwError}</p>}
+            {pwSuccess && <p className={styles.successMsg}>Password updated successfully.</p>}
+            <div className={styles.formFooter}>
+              <button
+                type="submit"
+                className={styles.btn}
+                disabled={pwLoading || !currentPassword || !newPassword || !confirmPassword}
+              >
+                {pwLoading ? 'Saving…' : 'Update password'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      {/* ── Danger zone ── */}
+      <section className={styles.sectionDanger}>
+        <div className={styles.sectionInner}>
+          <h2 className={styles.sectionTitleDanger}>Danger zone</h2>
+          <div className={styles.dangerRow}>
+            <div>
+              <p className={styles.dangerRowLabel}>Sign out of all devices</p>
+              <p className={styles.dangerRowDesc}>
+                Revokes all active sessions. You will be redirected to the sign-in page.
+              </p>
+            </div>
+            <button
+              type="button"
+              className={styles.btnDanger}
+              onClick={handleSignOutAll}
+              disabled={signOutAllLoading}
+            >
+              {signOutAllLoading ? 'Signing out…' : 'Sign out everywhere'}
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- New `/settings` route rendered inside the protected `AppShell` layout
- **Settings** item added to the avatar dropdown (between the divider and Sign out), using the lucide `Settings` icon and existing `dropdownItem` style
- Three sections, each matching the existing card/token aesthetic (mono headers, `--surface` background, `--hairline` borders, `--radius-lg`):
  - **Email address** — update with Supabase `updateUser({ email })`, shows current address, success state prompts user to verify via inbox
  - **Change password** — re-authenticates with current password (`signInWithPassword`) before calling `updateUser({ password })`; validates match and minimum length client-side
  - **Danger zone** — "Sign out everywhere" calls `signOut({ scope: 'global' })` and redirects to `/login`
- Full dark-mode compatibility via CSS design tokens only (no hardcoded colours)
- Responsive: password field row stacks to single column on narrow screens

## Test plan
- [ ] Avatar dropdown shows **Settings** item above Sign out
- [ ] Navigating to `/settings` renders the page correctly in light and dark mode
- [ ] Email section: submitting the same address shows an inline error; submitting a new address shows the verification success message
- [ ] Password section: wrong current password shows "Current password is incorrect"; mismatched new passwords shows inline error; correct flow shows success message
- [ ] Danger zone: "Sign out everywhere" ends the session and redirects to `/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)