### PR TITLE
feat: render markdown in research chat messages

### DIFF
--- a/apps/web/src/hooks/useResearchChat.ts
+++ b/apps/web/src/hooks/useResearchChat.ts
@@ -4,7 +4,6 @@ import { useTrackActivity } from '@/hooks/useTrackActivity'
 import { supabase } from '@/lib/supabase'
 import { awardGamificationEvent, GAMIFICATION_EVENT_TYPES } from '@/lib/gamification'
 import type { Badge, Message } from '@/types'
-import { stripResearchChatMarkdown } from '@/utils/stripResearchChatMarkdown'
 
 const RATE_LIMIT_FRIENDLY_MESSAGE =
   'You are sending requests too quickly right now. Please wait a minute and try again.'
@@ -269,7 +268,7 @@ export function useResearchChat({
         setMessages((prev) =>
           prev.map((m) =>
             m.id === placeholder.id
-              ? { ...m, content: stripResearchChatMarkdown(m.content + chunk) }
+              ? { ...m, content: m.content + chunk }
               : m,
           ),
         )

--- a/apps/web/src/pages/ResearchPage.module.css
+++ b/apps/web/src/pages/ResearchPage.module.css
@@ -846,6 +846,69 @@
   border-radius: 14px 14px 4px 14px;
 }
 
+.markdown {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.markdown p {
+  margin: 0;
+}
+
+.markdown ul,
+.markdown ol {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.markdown li {
+  margin: 0;
+}
+
+.markdown strong {
+  font-weight: 600;
+}
+
+.markdown em {
+  font-style: italic;
+}
+
+.markdown h1,
+.markdown h2,
+.markdown h3 {
+  font-weight: 600;
+  margin: 0;
+}
+
+.markdown h1 { font-size: var(--font-lg); }
+.markdown h2 { font-size: var(--font-base); }
+.markdown h3 { font-size: var(--font-sm); }
+
+.markdown code {
+  font-family: monospace;
+  background-color: var(--hairline);
+  padding: 0.1em 0.3em;
+  border-radius: var(--radius-sm);
+  font-size: 0.85em;
+}
+
+.markdown pre {
+  background-color: var(--hairline);
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  overflow-x: auto;
+  margin: 0;
+}
+
+.markdown pre code {
+  background: none;
+  padding: 0;
+}
+
 .avatar {
   width: 28px;
   height: 28px;

--- a/apps/web/src/pages/ResearchPage.tsx
+++ b/apps/web/src/pages/ResearchPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
+import ReactMarkdown from 'react-markdown'
 import { Plus, Search, Send, X, Paperclip, Star, Trash2, ChevronRight, ChevronDown, Play, Briefcase } from 'lucide-react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
@@ -613,7 +614,13 @@ export default function ResearchPage() {
                       m.role === 'user' ? styles.messageUser : styles.messageAssistant,
                     )}
                   >
-                    {m.content}
+                    {m.role === 'assistant' ? (
+                      <div className={styles.markdown}>
+                        <ReactMarkdown>{m.content}</ReactMarkdown>
+                      </div>
+                    ) : (
+                      m.content
+                    )}
                   </div>
                   {m.role === 'user' && <span className={styles.avatar}>{userInitial}</span>}
                 </div>


### PR DESCRIPTION
## Summary
- Research board assistant messages now render with `ReactMarkdown`, matching the interview/practice chat
- Removed `stripResearchChatMarkdown` from the streaming path — it was actively stripping headers, bold, bullets, and code blocks before they could be displayed
- Added `.markdown` styles to `ResearchPage.module.css` (identical token-based rules to `ChatBox.module.css`): paragraphs, lists, headings, inline code, code blocks

## Before / After
**Before:** All AI responses rendered as a single wall of plain text with markdown syntax stripped out  
**After:** Responses render with proper headings, bullet lists, bold text, and code formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)